### PR TITLE
Fonctionnalité: Gestion des cours

### DIFF
--- a/config/commands/professors.ts
+++ b/config/commands/professors.ts
@@ -1,0 +1,149 @@
+/* eslint-disable import/prefer-default-export */
+import { stripIndent } from 'common-tags';
+
+export const eclass = {
+  options: {
+    aliases: ['cours', 'class', 'ecours', 'eclass', 'e-cours', 'e-class'],
+    description: stripIndent`
+      Commande permettant de créer un cours. Vous pouvez utiliser \`!cours create\` ou \`!cours add\` suivit de tous les arguments nécessaires (\`!cours help\`), ou vous laisser guider par \`!cours setup\`.
+      Quand le cours sera créé, des messages seront envoyés dans les bons salons pour prévenir les membres, et un rôle spécial sera créé pour que les personnes voulant assister au cours puissent être notifiées.
+      Vous pourrez ensuite lancer le cours manuellement avec \`!cours start @role-spécial\`. Le cours s'arrêtera au bout de la durée spécifiée. S'il se finit avant, vous pouvez l'arrêter manuellement avec \`cours finish @role-spécial\`
+    `,
+    enabled: true,
+    usage: 'cours <add|setup|help|start>',
+    examples: ['!cours setup', '!cours add #⚡-electricité-générale "Low and High pass filters" 24/04 20h30 2h15 @professeur @L1', '!cours start'],
+  },
+  messages: {
+    // Global
+    invalidClassId: "Désolé, mais cet identifiant n'est pas valide. L'identifiant de la classe a été envoyé quand elle a été crée, et il est toujours disponible dans l'embed d'annonce du cours.",
+    onlyProfessor: 'Seul les professeurs peuvent effectuer cette action !',
+    unresolvedProfessor: ':x: Impossible de retrouver le professeur pour ce cours !',
+    unconfiguredChannel: "Oups, impossible de créer ce cours car aucun salon n'a été configuré pour les annonces. Configurez-en un en tapant la commande `setup class` dans le bon salon.",
+
+    // Statuses
+    statuses: {
+      planned: "n'est pas encore commencé",
+      inProgress: 'est en cours',
+      finished: 'est terminé',
+      canceled: 'est annulé',
+    },
+
+    // Help subcommand
+    helpEmbedTitle: 'Aide de la commande de cours',
+    helpEmbedDescription: [
+      { name: "Créer un cours à partir d'arguments donnés", value: '`!cours create <#salon | salon | ID> <sujet> <date> <heure> <durée> <@professeur | professeur | ID> <@role-audience | role audience | ID>`' },
+      { name: 'Créer un cours de manière intéractive', value: '`!cours setup`' },
+      { name: 'Commencer un cours', value: '`!cours start ID-cours`' },
+      { name: 'Terminer un cours manuellement', value: '`!cours finish ID-cours`' },
+      { name: 'Modifier un cours', value: '`!cours edit ID-cours <propriété> <valeur>`\n`propriété`: "sujet", "date", "heure", "durée", "professeur", "rôle"' },
+      { name: 'Annuler un cours', value: '`!cours cancel ID-cours`' },
+      { name: "Page d'aide", value: '`!cours help`' },
+    ],
+
+    // Create subcommand
+    successfullyCreated: 'Le cours a bien été créé ! Son ID est {eclass.classId}',
+    alreadyExists: 'Ce cours (même matière, sujet, heure, jour) a déjà été prévu !',
+    newClassNotification: ':bell: {targetRole}, un nouveau cours a été plannifié ! :arrow_heading_down:',
+
+    invalidDate: "Cette date/heure est invalide. Vérifie bien qu'elle ne soit pas passée et qu'elle soit prévue pour dans moins de 2 mois.",
+
+    newClassEmbed: {
+      title: '{subject} - {topic}',
+      description: "Un nouveau cours en {classChannel} a été planifié sur Ef'Réussite !\nRéagis avec :white_check_mark: pour être notifié du cours !",
+      author: "Ef'Réussite - Nouveau cours !",
+      date: 'Date et heure',
+      duration: 'Durée prévue',
+      professor: 'Professeur',
+      footer: 'ID : {eclass.classId}',
+    },
+
+    // Edit subcommand
+    editUnauthorized: "Tu n'es pas autorisé à modifier ce cours !",
+    notEditable: 'Ce cours {status}, tu ne peux donc pas le modifier !',
+    invalidEditProperty: 'Cette propriété est invalide. Choisissez parmi "sujet", "date", "heure", "durée", "professeur", "rôle".',
+
+    editedTopic: 'Vous avez bien modifié le thème du cours en "{eclass.topic}".',
+    pingEditedTopic: '{role}, le cours a été modifié : le thème a été changé en "{eclass.topic}".',
+
+    editedDate: 'Vous avez bien modifié la date du cours pour le {eclass.date}.',
+    pingEditedDate: '{role}, le cours a été modifié : la date a été changée pour le {eclass.date}.',
+
+    editedHour: "Vous avez bien modifié l'heure du cours pour le {eclass.date}.",
+    pingEditedHour: "{role}, le cours a été modifié : l'heure a été changée pour le {eclass.date}.",
+
+    editedDuration: 'Vous avez bien modifié la durée du cours en {eclass.duration}.',
+    pingEditedDuration: '{role}, le cours a été modifié : la durée a été changée en {eclass.duration}.',
+
+    editedProfessor: 'Vous avez bien modifié le professeur du cours qui est maintenant <@{eclass.professor}>.',
+    pingEditedProfessor: '{role}, le cours a été modifié : le professeur est maintenant <@{eclass.professor}>.',
+
+    editedRole: 'Vous avez bien modifié le rôle visé en "{eclass.role}".',
+    pingEditedRole: '{role}, le cours a été modifié : le rôle visé est maintenant "{eclass.role}".',
+
+    // Start subcommand
+    successfullyStarted: 'Le cours a bien été lancé !',
+    startUnauthorized: "Tu n'es pas autorisé à lancer ce cours !",
+    alreadyStarted: 'Ce cours {status}, tu ne peux donc pas le re-lancer !',
+    startClassNotification: ':bell: <@&{classRole}>, le cours commence !',
+    remindClassNotification: ':bell: <@&{classRole}> rappel : le cours commence dans {duration}',
+    remindClassPrivateNotification: ":bell: Tu t'es inscrit au cours \"{eclass.topic}\". Il va commencer dans environ 15 minutes ! Tien-toi prêt :\\)",
+    valueInProgress: '[En cours]',
+
+    startClassEmbed: {
+      title: 'Le cours en {eclass.subject} va commencer !',
+      author: "Ef'Réussite - Un cours commence !",
+      description: 'Le cours en **{eclass.subject}** sur "**{eclass.topic}**" présenté par <@{eclass.professor}> commence ! Le salon textuel associé est <#{eclass.classChannel}>',
+      footer: 'ID : {eclass.classId}',
+    },
+
+    // Finish subcommand
+    successfullyFinished: 'Le cours a bien été terminé !',
+    finishUnauthorized: "Tu n'es pas autoriser à terminer ce cours !",
+    notFinishable: "Ce cours n'est pas lancé, tu ne peux donc pas le terminer !",
+    valueFinished: '[Terminé]',
+
+    // Cancel subcommand
+    successfullyCanceled: 'Le cours a bien été archivé !',
+    cancelUnauthorized: "Tu n'es pas autorisé à archiver ce cours !",
+    notCancellable: "Ce cours {status}, tu ne peux donc pas l'archiver !",
+    valueCanceled: ':warning: **__COURS ANNULÉ !__**',
+
+    // Subscribing
+    subscribed: "Tu t'es bien inscrit au cours de \"{topic}\" ({subject}) ! Je te le rappellerai un peu avant :)",
+    unsubscribed: "Tu t'es bien désinscrit du cours de \"{topic}\" ({subject}) !",
+
+    // Prompts
+    prompts: {
+      classChannel: {
+        base: 'Entrez le salon associé au cours que vous souhaitez donner (mentionnez-le ou entrez son nom ou son ID) :',
+        invalid: 'Ce salon de cours est invalide.',
+      },
+      topic: {
+        base: 'Entrez le sujet du cours que vous souhaitez donner (nom du chapitre, thème du cours...) :',
+        invalid: 'Ce sujet est invalide.',
+      },
+      date: {
+        base: 'Entrez la date du cours que vous souhaitez donner (au format "jj/MM") :',
+        invalid: 'Cette date est invalide.',
+      },
+      hour: {
+        base: "Entrez l'heure de début du cours que vous souhaitez donner (au format \"HH:mm\") :",
+        invalid: 'Cette heure est invalide.',
+      },
+      duration: {
+        base: 'Entrez une durée pour votre cours (en anglais ou en francais).\nVous pouvez par exemple entrer `30min` pour 30 minutes et `2h` pour 2 heures. Vous pouvez également combiner ces durées ensemble : `2h30min` est par exemple une durée valide.',
+        invalid: 'Cette durée est invalide.',
+      },
+      professor: {
+        base: 'Entrez le professeur qui va donner le cours (mentionnez-le ou entrez son pseudo ou son ID) :',
+        invalid: 'Ce membre est invalide.',
+      },
+      targetRole: {
+        base: 'Entrez le rôle visé (L1, L2...) (mentionnez-le ou entrez son nom ou son ID) :',
+        invalid: 'Ce rôle est invalide.',
+      },
+
+      stoppedPrompting: "Tu as bien abandonné la commande ! Aucun cours n'a été créé.",
+    },
+  },
+};

--- a/config/messages.ts
+++ b/config/messages.ts
@@ -44,4 +44,40 @@ export default {
       Merci !\n{message.url}
     `,
   },
+  prompts: {
+    channel: {
+      base: 'Entrez un salon (mentionnez-le ou entrez son nom ou son ID) :',
+      invalid: 'Ce salon est invalide.',
+    },
+    message: {
+      base: 'Entrez un message (son ID ou son URL) :',
+      invalid: 'Ce message est invalide.',
+    },
+    text: {
+      base: 'Entrez du texte :',
+      invalid: 'Ce texte est invalide.',
+    },
+    date: {
+      base: 'Entrez une date (au format "jj/MM")  :',
+      invalid: 'Cette date est invalide.',
+    },
+    hour: {
+      base: 'Entrez une heure (au format "HH:mm") :',
+      invalid: 'Cette heure est invalide.',
+    },
+    duration: {
+      base: 'Entrez une durée (en anglais ou en francais).\nVous pouvez par exemple entrer `30min` pour 30 minutes et `2h` pour 2 heures. Vous pouvez également combiner ces durées ensemble : `2h30min` est par exemple une durée valide.',
+      invalid: 'Cette durée est invalide.',
+    },
+    member: {
+      base: 'Entrez un membre (mentionnez-le ou entrez son pseudo ou son ID) :',
+      invalid: 'Ce membre est invalide.',
+    },
+    role: {
+      base: 'Entrez un rôle (mentionnez-le ou entrez son nom ou son ID) :',
+      invalid: 'Ce rôle est invalide.',
+    },
+
+    stoppedPrompting: 'Tu as bien abandonné la commande !',
+  },
 };

--- a/config/settings.ts
+++ b/config/settings.ts
@@ -34,6 +34,11 @@ export default {
     compiler: 'https://api.jdoodle.com/v1/execute',
     compilerCredits: 'https://api.jdoodle.com/v1/credit-spent',
   },
+  emojis: {
+    yes: '✅',
+    no: '❌',
+    remove: '🗑️',
+  },
   languages: [
     {
       language: 'bash',

--- a/config/settings.ts
+++ b/config/settings.ts
@@ -3,7 +3,13 @@ import type { CodeLanguageResult } from '@/types';
 export default {
   prefix: '!',
   colors: {
+    primary: '#5bb78f',
     default: '#439bf2',
+    white: '#ffffff',
+    green: '#32a852',
+    yellow: '#e0c748',
+    orange: '#f27938',
+    red: '#eb2d1c',
   },
   configuration: {
     swears: ['fleur', 'arbre', 'tulipe'], // ['putain', 'con', 'connard', 'fdp', 'pute', 'putes'],
@@ -12,6 +18,9 @@ export default {
     roleIntersectionExpiration: 2 * 24 * 60 * 60 * 1000, // 2 days
     flagMessageReaction: '🚩',
     flagNeededAnswer: '📝',
+    dateFormat: 'DD/MM [à] HH:mm',
+    eclassRoleFormat: '{subject}: {topic} ({formattedDate})',
+    eclassReminderTime: 15 * 60 * 1000, // 15 minutes
   },
   channels: {
     eProfsId: {
@@ -28,6 +37,7 @@ export default {
   roles: {
     // TODO: Move that to per-guild configuration (managed by ConfigurationManager)
     staff: '822900204742770749',
+    eprof: '838842486498656307',
   },
   apis: {
     latex: 'https://chart.apis.google.com/chart?cht=tx&chf=bg,s,FFFFFF00&chco=FFFFFF&chl=',

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,13 +30,17 @@
         "node-emoji": "^1.10.0",
         "pupa": "^2.1.1",
         "reflect-metadata": "^0.1.13",
-        "source-map-support": "^0.5.19"
+        "slug": "^5.0.1",
+        "source-map-support": "^0.5.19",
+        "twemoji": "^13.0.2"
       },
       "devDependencies": {
         "@types/common-tags": "^1.8.0",
         "@types/lodash.difference": "^4.5.6",
         "@types/node": "^14.14.41",
         "@types/node-emoji": "^1.8.1",
+        "@types/slug": "^0.9.1",
+        "@types/twemoji": "^12.1.1",
         "@types/ws": "^7.4.1",
         "@typescript-eslint/eslint-plugin": "^4.22.0",
         "@typescript-eslint/parser": "^4.22.0",
@@ -755,6 +759,18 @@
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
       "integrity": "sha512-f5j5b/Gf71L+dbqxIpQ4Z2WlmI/mPJ0fOkGGmFgtb6sAu97EPczzbS3/tJKxmcYDj55OX6ssqwDAWOHIYDRDGA==",
+      "dev": true
+    },
+    "node_modules/@types/slug": {
+      "version": "0.9.1",
+      "resolved": "https://registry.npmjs.org/@types/slug/-/slug-0.9.1.tgz",
+      "integrity": "sha512-zR/u8WFQ4/6uCIikjI00a5uB084XjgEGNRAvM4a1BL39Bw9yEiDQFiPS2DgJ8lPDkR2Qd/vZ26dCR9XqlKbDqQ==",
+      "dev": true
+    },
+    "node_modules/@types/twemoji": {
+      "version": "12.1.1",
+      "resolved": "https://registry.npmjs.org/@types/twemoji/-/twemoji-12.1.1.tgz",
+      "integrity": "sha512-dW1B1WHTfrWmEzXb/tp8xsZqQHAyMB9JwLwbBqkIQVzmNUI02R7lJqxUpKFM114ygNZHKA1r74oPugCAiYHt1A==",
       "dev": true
     },
     "node_modules/@types/ws": {
@@ -2251,6 +2267,27 @@
         }
       }
     },
+    "node_modules/fs-extra": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
+      "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^4.0.0",
+        "universalify": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=6 <7 || >=8"
+      }
+    },
+    "node_modules/fs-extra/node_modules/jsonfile": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+      "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
     "node_modules/fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
@@ -2371,8 +2408,7 @@
     "node_modules/graceful-fs": {
       "version": "4.2.6",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.6.tgz",
-      "integrity": "sha512-nTnJ528pbqxYanhpDYsi4Rd8MAeaBA67+RZ10CM1m3bTAVFEDcd5AuA4a6W5YkGZ1iNXHzZz8T6TBKLeBuNriQ==",
-      "dev": true
+      "integrity": "sha512-nTnJ528pbqxYanhpDYsi4Rd8MAeaBA67+RZ10CM1m3bTAVFEDcd5AuA4a6W5YkGZ1iNXHzZz8T6TBKLeBuNriQ=="
     },
     "node_modules/has": {
       "version": "1.0.3",
@@ -2728,6 +2764,17 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/jsonfile": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-5.0.0.tgz",
+      "integrity": "sha512-NQRZ5CRo74MhMMC3/3r5g2k4fjodJ/wh8MxjFbCViWKFjxrnudWSY5vomh+23ZaXzAS7J3fBZIR2dV6WbmfM0w==",
+      "dependencies": {
+        "universalify": "^0.1.2"
+      },
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
       }
     },
     "node_modules/kareem": {
@@ -3682,6 +3729,11 @@
       "resolved": "https://registry.npmjs.org/sliced/-/sliced-1.0.1.tgz",
       "integrity": "sha1-CzpmK10Ewxd7GSa+qCsD+Dei70E="
     },
+    "node_modules/slug": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/slug/-/slug-5.0.1.tgz",
+      "integrity": "sha512-2Jf7lg8IwV4yC93hdd009WJKrZHLB0lpNVHzGdlpgDgJixJuOlUHG/MaD446lQG2yjh7fQFrJeNW5agWvxMHCg=="
+    },
     "node_modules/source-map": {
       "version": "0.5.7",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
@@ -3972,6 +4024,17 @@
       "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-1.0.3.tgz",
       "integrity": "sha512-6rt+RN7aOi1nGMyC4Xa5DdYiukl2UWCbcJft7YhxReBGQD7OAM8Pbxw6YMo4r2diNEA8FEmu32YOn9rhaiE5yw=="
     },
+    "node_modules/twemoji": {
+      "version": "13.0.2",
+      "resolved": "https://registry.npmjs.org/twemoji/-/twemoji-13.0.2.tgz",
+      "integrity": "sha512-R9tDS4pEVczjVYM5SvoAJ0AcZ4EgG1h3yw1oi1m/yrXOH17OOjaaRxZU4r5TIHEy3xYbuZQLB/tJZyC6rpQVmA==",
+      "dependencies": {
+        "fs-extra": "^8.0.1",
+        "jsonfile": "^5.0.0",
+        "twemoji-parser": "13.0.0",
+        "universalify": "^0.1.2"
+      }
+    },
     "node_modules/twemoji-parser": {
       "version": "13.0.0",
       "resolved": "https://registry.npmjs.org/twemoji-parser/-/twemoji-parser-13.0.0.tgz",
@@ -4027,6 +4090,14 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/universalify": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
+      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
+      "engines": {
+        "node": ">= 4.0.0"
       }
     },
     "node_modules/uri-js": {
@@ -4718,6 +4789,18 @@
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
       "integrity": "sha512-f5j5b/Gf71L+dbqxIpQ4Z2WlmI/mPJ0fOkGGmFgtb6sAu97EPczzbS3/tJKxmcYDj55OX6ssqwDAWOHIYDRDGA==",
+      "dev": true
+    },
+    "@types/slug": {
+      "version": "0.9.1",
+      "resolved": "https://registry.npmjs.org/@types/slug/-/slug-0.9.1.tgz",
+      "integrity": "sha512-zR/u8WFQ4/6uCIikjI00a5uB084XjgEGNRAvM4a1BL39Bw9yEiDQFiPS2DgJ8lPDkR2Qd/vZ26dCR9XqlKbDqQ==",
+      "dev": true
+    },
+    "@types/twemoji": {
+      "version": "12.1.1",
+      "resolved": "https://registry.npmjs.org/@types/twemoji/-/twemoji-12.1.1.tgz",
+      "integrity": "sha512-dW1B1WHTfrWmEzXb/tp8xsZqQHAyMB9JwLwbBqkIQVzmNUI02R7lJqxUpKFM114ygNZHKA1r74oPugCAiYHt1A==",
       "dev": true
     },
     "@types/ws": {
@@ -5813,6 +5896,26 @@
       "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.13.3.tgz",
       "integrity": "sha512-DUgl6+HDzB0iEptNQEXLx/KhTmDb8tZUHSeLqpnjpknR70H0nC2t9N73BK6fN4hOvJ84pKlIQVQ4k5FFlBedKA=="
     },
+    "fs-extra": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
+      "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
+      "requires": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^4.0.0",
+        "universalify": "^0.1.0"
+      },
+      "dependencies": {
+        "jsonfile": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+          "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
+          "requires": {
+            "graceful-fs": "^4.1.6"
+          }
+        }
+      }
+    },
     "fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
@@ -5905,8 +6008,7 @@
     "graceful-fs": {
       "version": "4.2.6",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.6.tgz",
-      "integrity": "sha512-nTnJ528pbqxYanhpDYsi4Rd8MAeaBA67+RZ10CM1m3bTAVFEDcd5AuA4a6W5YkGZ1iNXHzZz8T6TBKLeBuNriQ==",
-      "dev": true
+      "integrity": "sha512-nTnJ528pbqxYanhpDYsi4Rd8MAeaBA67+RZ10CM1m3bTAVFEDcd5AuA4a6W5YkGZ1iNXHzZz8T6TBKLeBuNriQ=="
     },
     "has": {
       "version": "1.0.3",
@@ -6148,6 +6250,15 @@
       "dev": true,
       "requires": {
         "minimist": "^1.2.5"
+      }
+    },
+    "jsonfile": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-5.0.0.tgz",
+      "integrity": "sha512-NQRZ5CRo74MhMMC3/3r5g2k4fjodJ/wh8MxjFbCViWKFjxrnudWSY5vomh+23ZaXzAS7J3fBZIR2dV6WbmfM0w==",
+      "requires": {
+        "graceful-fs": "^4.1.6",
+        "universalify": "^0.1.2"
       }
     },
     "kareem": {
@@ -6834,6 +6945,11 @@
       "resolved": "https://registry.npmjs.org/sliced/-/sliced-1.0.1.tgz",
       "integrity": "sha1-CzpmK10Ewxd7GSa+qCsD+Dei70E="
     },
+    "slug": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/slug/-/slug-5.0.1.tgz",
+      "integrity": "sha512-2Jf7lg8IwV4yC93hdd009WJKrZHLB0lpNVHzGdlpgDgJixJuOlUHG/MaD446lQG2yjh7fQFrJeNW5agWvxMHCg=="
+    },
     "source-map": {
       "version": "0.5.7",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
@@ -7080,6 +7196,17 @@
       "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-1.0.3.tgz",
       "integrity": "sha512-6rt+RN7aOi1nGMyC4Xa5DdYiukl2UWCbcJft7YhxReBGQD7OAM8Pbxw6YMo4r2diNEA8FEmu32YOn9rhaiE5yw=="
     },
+    "twemoji": {
+      "version": "13.0.2",
+      "resolved": "https://registry.npmjs.org/twemoji/-/twemoji-13.0.2.tgz",
+      "integrity": "sha512-R9tDS4pEVczjVYM5SvoAJ0AcZ4EgG1h3yw1oi1m/yrXOH17OOjaaRxZU4r5TIHEy3xYbuZQLB/tJZyC6rpQVmA==",
+      "requires": {
+        "fs-extra": "^8.0.1",
+        "jsonfile": "^5.0.0",
+        "twemoji-parser": "13.0.0",
+        "universalify": "^0.1.2"
+      }
+    },
     "twemoji-parser": {
       "version": "13.0.0",
       "resolved": "https://registry.npmjs.org/twemoji-parser/-/twemoji-parser-13.0.0.tgz",
@@ -7117,6 +7244,11 @@
         "has-symbols": "^1.0.2",
         "which-boxed-primitive": "^1.0.2"
       }
+    },
+    "universalify": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
+      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg=="
     },
     "uri-js": {
       "version": "4.4.1",

--- a/package.json
+++ b/package.json
@@ -41,13 +41,17 @@
     "node-emoji": "^1.10.0",
     "pupa": "^2.1.1",
     "reflect-metadata": "^0.1.13",
-    "source-map-support": "^0.5.19"
+    "slug": "^5.0.1",
+    "source-map-support": "^0.5.19",
+    "twemoji": "^13.0.2"
   },
   "devDependencies": {
     "@types/common-tags": "^1.8.0",
     "@types/lodash.difference": "^4.5.6",
     "@types/node": "^14.14.41",
     "@types/node-emoji": "^1.8.1",
+    "@types/slug": "^0.9.1",
+    "@types/twemoji": "^12.1.1",
     "@types/ws": "^7.4.1",
     "@typescript-eslint/eslint-plugin": "^4.22.0",
     "@typescript-eslint/parser": "^4.22.0",

--- a/src/arguments/day.ts
+++ b/src/arguments/day.ts
@@ -1,0 +1,31 @@
+import type { ArgumentContext, ArgumentResult } from '@sapphire/framework';
+import { Argument } from '@sapphire/framework';
+
+const DATE_REGEX = /^(?<day>\d{1,2})[/-](?<month>\d{1,2})(?:[/-](?<year>\d{1,4}))?$/imu;
+
+export default class HourArgument extends Argument<Date> {
+  public run(arg: string, _context: ArgumentContext<Date>): ArgumentResult<Date> {
+    if (!DATE_REGEX.test(arg))
+      return this.error({ parameter: arg });
+
+    const groups = DATE_REGEX.exec(arg)?.groups;
+    const date = new Date();
+    const month = Number.parseInt(groups?.month, 10) - 1;
+    const day = Number.parseInt(groups?.day, 10);
+    const year = Number.parseInt(groups?.year, 10);
+    date.setMonth(month);
+    date.setDate(day);
+    date.setHours(0, 0, 0, 0);
+
+    if (groups.year)
+      date.setFullYear(year);
+    else if (month < new Date().getMonth())
+      date.setFullYear(year + 1);
+
+    const time = date.getTime();
+    if (Number.isNaN(time))
+      return this.error({ parameter: arg });
+
+    return this.ok(date);
+  }
+}

--- a/src/arguments/duration.ts
+++ b/src/arguments/duration.ts
@@ -1,0 +1,13 @@
+import type { ArgumentContext, ArgumentResult } from '@sapphire/framework';
+import { Argument } from '@sapphire/framework';
+import { getDuration } from '@/utils';
+
+export default class CodeArgument extends Argument<number> {
+  public run(arg: string, _context: ArgumentContext<number>): ArgumentResult<number> {
+    try {
+      return this.ok(getDuration(arg) * 1000);
+    } catch {
+      return this.error({ parameter: arg });
+    }
+  }
+}

--- a/src/arguments/hour.ts
+++ b/src/arguments/hour.ts
@@ -1,0 +1,20 @@
+import type { ArgumentContext, ArgumentResult } from '@sapphire/framework';
+import { Argument } from '@sapphire/framework';
+import type { HourMinutes } from '@/types';
+
+const HOUR_REGEX = /^(?<hour>\d{1,2})[h:]?(?<minutes>\d{2})?$/imu;
+
+export default class HourArgument extends Argument<HourMinutes> {
+  public run(arg: string, _context: ArgumentContext<HourMinutes>): ArgumentResult<HourMinutes> {
+    const hour = Number.parseInt(HOUR_REGEX.exec(arg)?.groups?.hour, 10);
+    const minutes = Number.parseInt(HOUR_REGEX.exec(arg)?.groups?.minutes, 10) || 0;
+
+    if (!hour)
+      return this.error({ parameter: arg });
+    return this.ok({
+      hour,
+      minutes,
+      formatted: `${hour}h${minutes.toString().padStart(2, '0')}`,
+    });
+  }
+}

--- a/src/commands/Admin/reactionRole.ts
+++ b/src/commands/Admin/reactionRole.ts
@@ -9,26 +9,21 @@ import pupa from 'pupa';
 import { reactionRole as config } from '@/config/commands/admin';
 import settings from '@/config/settings';
 import ReactionRole from '@/models/reactionRole';
+import ArgumentPrompter from '@/structures/ArgumentPrompter';
 import ArgumentResolver from '@/structures/ArgumentResolver';
 import MonkaSubCommand from '@/structures/MonkaSubCommand';
-import type { GuildMessage, GuildTextBasedChannel, ReactionRolePair } from '@/types';
+import type {
+  GuildMessage,
+  GuildTextBasedChannel,
+  ReactionRolePair,
+  ReactionRoleReturnPayload,
+} from '@/types';
 import {
   commaListAnd,
   firstAndRest,
   generateSubcommands,
   nullop,
 } from '@/utils';
-
-interface ReactionRoleReturnPayload {
-  isError: boolean;
-  errorPayload?: {
-    reactions?: string[];
-    roles?: string[];
-  };
-  reactionRoles: ReactionRolePair[];
-}
-
-const STOP_ERROR = 'stop_error';
 
 @ApplyOptions<SubCommandPluginCommandOptions>({
   ...config.options,
@@ -37,7 +32,7 @@ const STOP_ERROR = 'stop_error';
     start: { aliases: ['make', 'setup', 'create', 'add'] },
     list: { aliases: ['liste', 'show'] },
     remove: { aliases: ['delete', 'supprimer', 'supprime', 'suppr', 'rm', 'rem', 'del'] },
-    help: { default: true },
+    help: { aliases: ['aide'], default: true },
   }),
 })
 export default class SetupCommand extends MonkaSubCommand {
@@ -50,13 +45,13 @@ export default class SetupCommand extends MonkaSubCommand {
     // 1. Ask all the necessary questions
     try {
       if (!channel)
-        channel = await this._promptChannel(message);
+        channel = await new ArgumentPrompter(message).promptTextChannel();
 
       [title, description] = await this._promptTitle(message);
 
-      roles = await this._promptRolesSafe(message);
+      roles = await this._promptReactionRolesSafe(message);
     } catch (error: unknown) {
-      if ((error as Error).message === STOP_ERROR) {
+      if ((error as Error).message === 'STOP') {
         await message.channel.send(config.messages.stoppedPrompting);
         return;
       }
@@ -75,8 +70,8 @@ export default class SetupCommand extends MonkaSubCommand {
         }),
       );
     const handler = new MessagePrompter(confirmationEmbed, MessagePrompterStrategies.Confirm, {
-      confirmEmoji: '✅',
-      cancelEmoji: '❌',
+      confirmEmoji: settings.emojis.yes,
+      cancelEmoji: settings.emojis.no,
       timeout: 60 * 1000,
     });
     const isConfirmed = await handler.run(message.channel, message.author).catch(nullop);
@@ -135,8 +130,10 @@ export default class SetupCommand extends MonkaSubCommand {
 
   public async remove(message: GuildMessage, args: Args): Promise<void> {
     let givenMessage = (await args.pickResult('message')).value;
-    while (!givenMessage)
-      givenMessage = await this._promptMessage(message);
+    if (!givenMessage) {
+      const argumentPrompter = new ArgumentPrompter(message);
+      givenMessage = await argumentPrompter.autoPromptMessage();
+    }
 
     const isRrMenu = this.context.client.reactionRolesIds.includes(givenMessage.id);
     if (!isRrMenu) {
@@ -158,35 +155,6 @@ export default class SetupCommand extends MonkaSubCommand {
     await message.channel.send(embed);
   }
 
-  private async _promptMessage(message: GuildMessage): Promise<GuildMessage> {
-    const handler = new MessagePrompter(
-      config.messages.removePrompt,
-      MessagePrompterStrategies.Message,
-      { timeout: 60 * 1000 },
-    );
-    const result = await handler.run(message.channel, message.author) as GuildMessage;
-    if (settings.configuration.stop.has(result.content))
-      throw new Error(STOP_ERROR);
-
-    return await ArgumentResolver.resolveMessageByID(result.content, result.channel)
-      ?? await ArgumentResolver.resolveMessageByLink(result.content, result.guild, result.author);
-  }
-
-  private async _promptChannel(message: GuildMessage): Promise<GuildTextBasedChannel> {
-    const handler = new MessagePrompter(
-      config.messages.channelPrompt,
-      MessagePrompterStrategies.Message,
-      { timeout: 60 * 1000 },
-    );
-    const result = await handler.run(message.channel, message.author) as GuildMessage;
-    if (settings.configuration.stop.has(result.content))
-      throw new Error(STOP_ERROR);
-
-    const query = result.content.split(' ').join('-');
-    return ArgumentResolver.resolveChannelByID(query, result.guild)
-      ?? ArgumentResolver.resolveChannelByQuery(query, result.guild);
-  }
-
   private async _promptTitle(message: GuildMessage): Promise<[title: string, description: string]> {
     const handler = new MessagePrompter(
       config.messages.titlePrompt,
@@ -195,16 +163,16 @@ export default class SetupCommand extends MonkaSubCommand {
     );
     const result = await handler.run(message.channel, message.author) as GuildMessage;
     if (settings.configuration.stop.has(result.content))
-      throw new Error(STOP_ERROR);
+      throw new Error('STOP');
 
     return firstAndRest(result.content, '\n');
   }
 
-  private async _promptRolesSafe(message: GuildMessage): Promise<ReactionRolePair[]> {
-    let roles = await this._promptRoles(message);
+  private async _promptReactionRolesSafe(message: GuildMessage): Promise<ReactionRolePair[]> {
+    let roles = await this._promptReactionRoles(message);
 
     while (roles.isError || roles.reactionRoles.length === 0) {
-      roles = await this._promptRoles(message);
+      roles = await this._promptReactionRoles(message);
 
       if (roles.isError) {
         if (roles.errorPayload.reactions.length > 0) {
@@ -228,7 +196,7 @@ export default class SetupCommand extends MonkaSubCommand {
     return roles.reactionRoles;
   }
 
-  private async _promptRoles(message: GuildMessage): Promise<ReactionRoleReturnPayload> {
+  private async _promptReactionRoles(message: GuildMessage): Promise<ReactionRoleReturnPayload> {
     const handler = new MessagePrompter(
       config.messages.rolesPrompt,
       MessagePrompterStrategies.Message,
@@ -236,7 +204,7 @@ export default class SetupCommand extends MonkaSubCommand {
     );
     const result = await handler.run(message.channel, message.author) as GuildMessage;
     if (settings.configuration.stop.has(result.content))
-      throw new Error(STOP_ERROR);
+      throw new Error('STOP');
 
     const lines = result.content.split('\n').filter(Boolean).slice(0, 20);
     const payload: ReactionRoleReturnPayload = { isError: false, errorPayload: {}, reactionRoles: [] };

--- a/src/commands/Admin/setup.ts
+++ b/src/commands/Admin/setup.ts
@@ -7,10 +7,12 @@ import { ConfigEntries } from '@/types/database';
 
 @ApplyOptions<CommandOptions>(config.options)
 export default class SetupCommand extends MonkaCommand {
+  // eslint-disable-next-line complexity
   public async run(message: GuildMessage, args: Args): Promise<void> {
     // TODO: Add subcommands to get/set/remove/list etc
-    const channel = await args.pickResult('string');
-    switch (channel.value) {
+    const channelType = await args.pickResult('string');
+    const channel = (await args.pickResult('guildTextBasedChannel'))?.value || message.channel;
+    switch (channelType.value) {
       case 'moderator':
       case 'moderators':
       case 'moderateur':
@@ -19,7 +21,43 @@ export default class SetupCommand extends MonkaCommand {
       case 'modos':
       case 'mod':
       case 'mods':
-        await this.context.client.configManager.set(ConfigEntries.ModeratorFeedback, message.channel);
+        await this.context.client.configManager.set(ConfigEntries.ModeratorFeedback, channel);
+        await message.channel.send(config.messages.successfullyDefined);
+        break;
+      case 'class-l1':
+      case 'eclass-l1':
+      case 'classe-l1':
+      case 'eclasse-l1':
+      case 'cours-l1':
+      case 'ecours-l1':
+        await this.context.client.configManager.set(ConfigEntries.ClassAnnoucementL1, channel);
+        await message.channel.send(config.messages.successfullyDefined);
+        break;
+      case 'class-l2':
+      case 'eclass-l2':
+      case 'classe-l2':
+      case 'eclasse-l2':
+      case 'cours-l2':
+      case 'ecours-l2':
+        await this.context.client.configManager.set(ConfigEntries.ClassAnnoucementL2, channel);
+        await message.channel.send(config.messages.successfullyDefined);
+        break;
+      case 'class-l3':
+      case 'eclass-l3':
+      case 'classe-l3':
+      case 'eclasse-l3':
+      case 'cours-l3':
+      case 'ecours-l3':
+        await this.context.client.configManager.set(ConfigEntries.ClassAnnoucementL3, channel);
+        await message.channel.send(config.messages.successfullyDefined);
+        break;
+      case 'class-general':
+      case 'eclass-general':
+      case 'classe-general':
+      case 'eclasse-general':
+      case 'cours-general':
+      case 'ecours-general':
+        await this.context.client.configManager.set(ConfigEntries.ClassAnnoucementGeneral, channel);
         await message.channel.send(config.messages.successfullyDefined);
         break;
       default:

--- a/src/commands/Professors/eclass.ts
+++ b/src/commands/Professors/eclass.ts
@@ -1,0 +1,471 @@
+import { ApplyOptions } from '@sapphire/decorators';
+import type { Args } from '@sapphire/framework';
+import type { SubCommandPluginCommandOptions } from '@sapphire/plugin-subcommands';
+import dayjs from 'dayjs';
+import type { GuildMember, Role } from 'discord.js';
+import { MessageEmbed } from 'discord.js';
+import pupa from 'pupa';
+import { eclass as config } from '@/config/commands/professors';
+import messages from '@/config/messages';
+import settings from '@/config/settings';
+import Eclass from '@/models/eclass';
+import ArgumentPrompter from '@/structures/ArgumentPrompter';
+import EclassManager from '@/structures/EclassManager';
+import MonkaSubCommand from '@/structures/MonkaSubCommand';
+import type { GuildMessage, GuildTextBasedChannel, HourMinutes } from '@/types';
+import { EclassStatus } from '@/types/database';
+import { generateSubcommands, nullop } from '@/utils';
+
+@ApplyOptions<SubCommandPluginCommandOptions>({
+  ...config.options,
+  generateDashLessAliases: true,
+  strategyOptions: {
+    flags: ['ping'],
+  },
+  subCommands: generateSubcommands({
+    create: { aliases: ['add'] },
+    setup: { aliases: ['build', 'make'] },
+    start: { aliases: ['begin'] },
+    edit: { aliases: ['modify'] },
+    cancel: { aliases: ['archive'] },
+    finish: { aliases: ['end'] },
+    help: { aliases: ['aide'], default: true },
+  }),
+})
+export default class EclassCommand extends MonkaSubCommand {
+  public async create(message: GuildMessage, args: Args): Promise<void> {
+    if (!message.member.roles.cache.has(settings.roles.eprof)) {
+      await message.channel.send(config.messages.onlyProfessor);
+      return;
+    }
+
+    const classChannel = await args.pickResult('guildTextBasedChannel');
+    if (classChannel.error) {
+      await message.channel.send(config.messages.prompts.classChannel.invalid);
+      return;
+    }
+
+    const topic = await args.pickResult('string');
+    if (topic.error) {
+      await message.channel.send(config.messages.prompts.topic.invalid);
+      return;
+    }
+
+    const date = await args.pickResult('day');
+    if (date.error) {
+      await message.channel.send(config.messages.prompts.date.invalid);
+      return;
+    }
+
+    const hour = await args.pickResult('hour');
+    if (hour.error) {
+      await message.channel.send(config.messages.prompts.hour.invalid);
+      return;
+    }
+
+    date.value.setHours(hour.value.hour);
+    date.value.setMinutes(hour.value.minutes);
+    if (!dayjs(date.value).isBetween(dayjs(), dayjs().add(2, 'month'))) {
+      await message.channel.send(config.messages.invalidDate);
+      return;
+    }
+
+    const duration = await args.pickResult('duration');
+    if (duration.error) {
+      await message.channel.send(config.messages.prompts.duration.invalid);
+      return;
+    }
+
+    const professor = await args.pickResult('member');
+    if (professor.error) {
+      await message.channel.send(config.messages.prompts.professor.invalid);
+      return;
+    }
+
+    const targetRole = await args.pickResult('role');
+    if (targetRole.error) {
+      await message.channel.send(config.messages.prompts.targetRole.invalid);
+      return;
+    }
+
+    await EclassManager.createClass(message, {
+      date: date.value,
+      classChannel: classChannel.value,
+      topic: topic.value,
+      duration: duration.value,
+      professor: professor.value,
+      targetRole: targetRole.value,
+    });
+  }
+
+  public async setup(message: GuildMessage): Promise<void> {
+    if (!message.member.roles.cache.has(settings.roles.eprof)) {
+      await message.channel.send(config.messages.onlyProfessor);
+      return;
+    }
+
+    let classChannel: GuildTextBasedChannel;
+    let topic: string;
+    let date: Date;
+    let hour: HourMinutes;
+    let duration: number;
+    let professor: GuildMember;
+    let targetRole: Role;
+
+    try {
+      const allMessages: GuildMessage[] = [];
+      const prompter = new ArgumentPrompter(message, allMessages);
+
+      classChannel = await prompter.autoPromptTextChannel(config.messages.prompts.classChannel);
+      topic = await prompter.autoPromptText(config.messages.prompts.topic);
+      date = await prompter.autoPromptDate(config.messages.prompts.date);
+      hour = await prompter.autoPromptHour(config.messages.prompts.hour);
+      date.setHours(hour.hour);
+      date.setMinutes(hour.minutes);
+      while (!dayjs(date).isBetween(dayjs(), dayjs().add(2, 'month'))) {
+        await message.channel.send(config.messages.invalidDate);
+        date = await prompter.autoPromptDate(config.messages.prompts.date);
+        hour = await prompter.autoPromptHour(config.messages.prompts.hour);
+        date.setHours(hour.hour);
+        date.setMinutes(hour.minutes);
+      }
+      duration = await prompter.autoPromptDuration(config.messages.prompts.duration);
+      professor = await prompter.autoPromptMember(config.messages.prompts.professor);
+      targetRole = await prompter.autoPromptRole(config.messages.prompts.targetRole);
+    } catch (error: unknown) {
+      if ((error as Error).message === 'STOP') {
+        await message.channel.send(messages.prompts.stoppedPrompting);
+        return;
+      }
+      throw error;
+    }
+
+    await EclassManager.createClass(message, {
+      date,
+      classChannel,
+      topic,
+      duration,
+      professor,
+      targetRole,
+    });
+  }
+
+  public async start(message: GuildMessage, args: Args): Promise<void> {
+    // Get the class ID
+    const classId = await args.pickResult('string');
+    if (classId.error) {
+      await message.channel.send(config.messages.invalidClassId);
+      return;
+    }
+
+    // Fetch the class document from the database
+    const eclass = await Eclass.findOne({ classId: classId.value });
+    if (!eclass) {
+      await message.channel.send(config.messages.invalidClassId);
+      return;
+    }
+
+    // Check if the professor is the right one
+    if (message.member.id !== eclass.professor && message.member.roles.cache.has(settings.roles.staff)) {
+      await message.channel.send(config.messages.editUnauthorized);
+      return;
+    }
+
+    // If the class is already started/finished/cancel, you cannot start it.
+    if (eclass.status !== EclassStatus.Planned) {
+      await message.channel.send(pupa(config.messages.alreadyStarted, { status: EclassManager.toStatus(eclass) }));
+      return;
+    }
+
+    // Fetch the member
+    const professor = await message.guild.members.fetch(eclass.professor).catch(nullop);
+    if (!professor) {
+      await message.channel.send(config.messages.unresolvedProfessor);
+      return;
+    }
+
+    // Start the class & confirm.
+    await EclassManager.startClass(eclass);
+    await message.channel.send(config.messages.successfullyStarted);
+    // TODO: Send messages to members in DM
+  }
+
+  public async help(message: GuildMessage, _args: Args): Promise<void> {
+    const embed = new MessageEmbed()
+      .setTitle(config.messages.helpEmbedTitle)
+      .addFields(config.messages.helpEmbedDescription)
+      .setColor(settings.colors.default);
+
+    await message.channel.send(embed);
+  }
+
+  // eslint-disable-next-line complexity
+  public async edit(message: GuildMessage, args: Args): Promise<void> {
+    // Get the class ID
+    const classId = await args.pickResult('string');
+    if (classId.error) {
+      await message.channel.send(config.messages.invalidClassId);
+      return;
+    }
+
+    // Fetch the class document from the database
+    let eclass = await Eclass.findOne({ classId: classId.value });
+    if (!eclass) {
+      await message.channel.send(config.messages.invalidClassId);
+      return;
+    }
+
+    // Check if the professor is the right one
+    if (message.member.id !== eclass.professor && message.member.roles.cache.has(settings.roles.staff)) {
+      await message.channel.send(config.messages.editUnauthorized);
+      return;
+    }
+
+    // If the class is already started/finished/cancel, you cannot edit it.
+    if (eclass.status !== EclassStatus.Planned) {
+      await message.channel.send(pupa(config.messages.notEditable, { status: EclassManager.toStatus(eclass) }));
+      return;
+    }
+
+    // Resolve the given arguments & validate them
+    const shouldPing = args.getFlags('ping');
+    const property = await args.pickResult('string');
+    if (property.error) {
+      await message.channel.send(config.messages.invalidEditProperty);
+      return;
+    }
+
+    let updateMessage: string;
+    let notificationMessage: string;
+
+    switch (property.value) {
+      case 'topic':
+      case 'thème':
+      case 'theme':
+      case 'sujet': {
+        const topic = await args.restResult('string');
+        if (topic.error) {
+          await message.channel.send(config.messages.prompts.topic.invalid);
+          return;
+        }
+
+        eclass = await Eclass.findByIdAndUpdate(
+          eclass._id,
+          { topic: topic.value },
+          { new: true },
+        );
+        updateMessage = config.messages.editedTopic;
+        notificationMessage = config.messages.pingEditedTopic;
+        break;
+      }
+
+      case 'date': {
+        const newDate = await args.pickResult('day');
+        if (newDate.error) {
+          await message.channel.send(config.messages.prompts.date.invalid);
+          return;
+        }
+
+        const date = new Date(eclass.date);
+        date.setMonth(newDate.value.getMonth());
+        date.setDate(newDate.value.getDate());
+
+        eclass = await Eclass.findByIdAndUpdate(
+          eclass._id,
+          { date: date.getTime(), end: date.getTime() + eclass.duration },
+          { new: true },
+        );
+        updateMessage = config.messages.editedDate;
+        notificationMessage = config.messages.pingEditedDate;
+        break;
+      }
+
+      case 'hour':
+      case 'heure': {
+        const newHour = await args.pickResult('hour');
+        if (newHour.error) {
+          await message.channel.send(config.messages.prompts.hour.invalid);
+          return;
+        }
+
+        const date = new Date(eclass.date);
+        date.setHours(newHour.value.hour);
+        date.setMinutes(newHour.value.minutes);
+
+        eclass = await Eclass.findByIdAndUpdate(
+          eclass._id,
+          { date: date.getTime(), end: date.getTime() + eclass.duration },
+          { new: true },
+        );
+        updateMessage = config.messages.editedHour;
+        notificationMessage = config.messages.pingEditedHour;
+        break;
+      }
+
+      case 'duration':
+      case 'duree':
+      case 'durée': {
+        const duration = await args.pickResult('duration');
+        if (duration.error) {
+          await message.channel.send(config.messages.prompts.duration.invalid);
+          return;
+        }
+
+        eclass = await Eclass.findByIdAndUpdate(
+          eclass._id,
+          { duration: duration.value, end: eclass.date + duration.value },
+          { new: true },
+        );
+        updateMessage = config.messages.editedDuration;
+        notificationMessage = config.messages.pingEditedDuration;
+        break;
+      }
+
+      case 'professor':
+      case 'professeur':
+      case 'prof': {
+        const professor = await args.pickResult('member');
+        if (professor.error) {
+          await message.channel.send(config.messages.prompts.professor.invalid);
+          return;
+        }
+
+        eclass = await Eclass.findByIdAndUpdate(
+          eclass._id,
+          { professor: professor.value.id },
+          { new: true },
+        );
+        updateMessage = config.messages.editedProfessor;
+        notificationMessage = config.messages.pingEditedProfessor;
+        break;
+      }
+
+      case 'role':
+      case 'rôle': {
+        const targetRole = await args.pickResult('role');
+        if (targetRole.error) {
+          await message.channel.send(config.messages.prompts.targetRole.invalid);
+          return;
+        }
+
+        eclass = await Eclass.findByIdAndUpdate(
+          eclass._id,
+          { targetRole: targetRole.value.id },
+          { new: true },
+        );
+        updateMessage = config.messages.editedRole;
+        notificationMessage = config.messages.pingEditedRole;
+        break;
+      }
+
+      default:
+        await message.channel.send(config.messages.invalidEditProperty);
+        return;
+    }
+
+    // Fetch the annoucement message
+    const originalChannel = await this.context.client.configManager.get(message.guild.id, eclass.announcementChannel);
+    const originalMessage = await originalChannel.messages.fetch(eclass.announcementMessage);
+
+    // Edit the announcement embed
+    const formattedDate = dayjs(eclass.date).format(settings.configuration.dateFormat);
+    const classChannel = message.guild.channels.resolve(eclass.classChannel) as GuildTextBasedChannel;
+    const { subject, topic, duration } = eclass;
+    await originalMessage.edit({
+      content: originalMessage.content,
+      embed: EclassManager.createAnnoucementEmbed({
+        subject,
+        topic,
+        formattedDate,
+        duration,
+        professor: await message.guild.members.fetch(eclass.professor),
+        classChannel,
+        classId: classId.value,
+      }),
+    });
+    // Edit the role
+    const originalRole = message.guild.roles.resolve(eclass.classRole);
+    const newRoleName = pupa(settings.configuration.eclassRoleFormat, { subject, topic, formattedDate });
+    if (originalRole.name !== newRoleName)
+      await originalRole.setName(newRoleName);
+
+    // Send messages
+    const payload = {
+      eclass: { ...eclass.toData(), role: message.guild.roles.resolve(eclass.targetRole).name },
+    };
+    await message.channel.send(pupa(updateMessage, payload));
+    if (shouldPing)
+      await classChannel.send(pupa(notificationMessage, payload));
+  }
+
+  public async cancel(message: GuildMessage, args: Args): Promise<void> {
+    // Get the class ID
+    const classId = await args.pickResult('string');
+    if (classId.error) {
+      await message.channel.send(config.messages.invalidClassId);
+      return;
+    }
+
+    // Fetch the class document from the database
+    const eclass = await Eclass.findOne({ classId: classId.value });
+    if (!eclass) {
+      await message.channel.send(config.messages.invalidClassId);
+      return;
+    }
+
+    // Check if the professor is the right one
+    if (message.member.id !== eclass.professor && message.member.roles.cache.has(settings.roles.staff)) {
+      await message.channel.send(config.messages.cancelUnauthorized);
+      return;
+    }
+
+    // If the class is already canceled/finished, you cannot cancel it.
+    if (eclass.status === EclassStatus.Canceled || eclass.status === EclassStatus.Finished) {
+      await message.channel.send(pupa(config.messages.notCancellable, { status: EclassManager.toStatus(eclass) }));
+      return;
+    }
+
+    // Cancel the class & confirm.
+    await EclassManager.cancelClass(eclass);
+    await message.channel.send(config.messages.successfullyCanceled);
+  }
+
+  public async finish(message: GuildMessage, args: Args): Promise<void> {
+    // Get the class ID
+    const classId = await args.pickResult('string');
+    if (classId.error) {
+      await message.channel.send(config.messages.invalidClassId);
+      return;
+    }
+
+    // Fetch the class document from the database
+    const eclass = await Eclass.findOne({ classId: classId.value });
+    if (!eclass) {
+      await message.channel.send(config.messages.invalidClassId);
+      return;
+    }
+
+    // Check if the professor is the right one
+    if (message.member.id !== eclass.professor && message.member.roles.cache.has(settings.roles.staff)) {
+      await message.channel.send(config.messages.finishUnauthorized);
+      return;
+    }
+
+    // If the class is not started, you cannot finish it.
+    if (eclass.status !== EclassStatus.InProgress) {
+      await message.channel.send(config.messages.notFinishable);
+      return;
+    }
+
+    // Fetch the member
+    const professor = await message.guild.members.fetch(eclass.professor).catch(nullop);
+    if (!professor) {
+      await message.channel.send(config.messages.unresolvedProfessor);
+      return;
+    }
+
+    // Finish the class & confirm.
+    await EclassManager.finishClass(eclass);
+    await message.channel.send(config.messages.successfullyFinished);
+  }
+}

--- a/src/events/messageReactionAdd.ts
+++ b/src/events/messageReactionAdd.ts
@@ -27,7 +27,7 @@ export default class MessageReactionAddEvent extends Event {
 
     // If we are reacting to a flag message alert
     if (this.context.client.waitingFlaggedMessages.some(msg => msg.alertMessage.id === reaction.message.id)
-      && reaction.emoji.name === '✅')
+      && reaction.emoji.name === settings.emojis.yes)
       await this._handleModeratorFlag(reaction, member, message);
 
     // Si quelqu'un a besoin d'un professeur en urgence, un modérateur pourra 'flag' sa question
@@ -93,7 +93,7 @@ export default class MessageReactionAddEvent extends Event {
     message: GuildMessage,
   ): Promise<void> {
     // Wait for a moderator to approve the suppression of the message
-    if (reaction.emoji.name !== '✅')
+    if (reaction.emoji.name !== settings.emojis.yes)
       return;
 
     const flagMessage = this.context.client.waitingFlaggedMessages.find(msg => msg.alertMessage.id === message.id);

--- a/src/events/messageReactionRemove.ts
+++ b/src/events/messageReactionRemove.ts
@@ -1,8 +1,11 @@
 import { Event } from '@sapphire/framework';
-import type { MessageReaction, User } from 'discord.js';
+import type { GuildMember, MessageReaction, User } from 'discord.js';
+import settings from '@/config/settings';
+import Eclass from '@/models/eclass';
 import ReactionRole from '@/models/reactionRole';
+import EclassManager from '@/structures/EclassManager';
 import type { GuildMessage } from '@/types';
-import { noop } from '../lib/utils';
+import { noop } from '@/utils';
 
 export default class MessageReactionRemoveEvent extends Event {
   public async run(reaction: MessageReaction, user: User): Promise<void> {
@@ -10,36 +13,60 @@ export default class MessageReactionRemoveEvent extends Event {
       return;
 
     const message = reaction.message as GuildMessage;
+    const member = message.guild.members.cache.get(user.id);
+    if (!member) {
+      this.context.logger.warn('[Message Reaction Remove] Abort even due to unresolved member.');
+      return;
+    }
 
     // If we are reacting to a reaction role
-    if (this.context.client.reactionRolesIds.includes(reaction.message.id)) {
-      const document = await ReactionRole.findOne({ messageId: message.id });
-      if (!document) {
-        this.context.client.reactionRolesIds = this.context.client.reactionRolesIds.filter(elt => elt !== message.id);
-        return;
-      }
+    if (this.context.client.reactionRolesIds.includes(reaction.message.id))
+      await this._handleReactionRole(reaction, member, message);
 
-      const { reaction: emoji, role: givenRoleId } = document.reactionRolePairs
-        .find(elt => elt.reaction === reaction.emoji.toString());
-      if (!emoji) {
-        reaction.remove().catch(noop);
-        return;
-      }
+    // If we are reacting to an eclass role
+    if (this.context.client.eclassRolesIds.includes(reaction.message.id) && reaction.emoji.name === settings.emojis.yes)
+      await this._handleEclassRole(reaction, member, message);
+  }
 
-      const givenRole = message.guild.roles.cache.get(givenRoleId);
-      if (!givenRole) {
-        this.context.logger.warn(`[Reaction Roles] The role with id ${givenRoleId} does not exists !`);
-        return;
-      }
-
-      const member = message.guild.members.cache.get(user.id);
-      if (!member) {
-        this.context.logger.warn(`[Reaction Roles] An error has occured while trying to get member with id ${user.id}`);
-        return;
-      }
-
-      if (member.roles.cache.get(givenRole.id))
-        await member.roles.remove(givenRole);
+  private async _handleReactionRole(
+    reaction: MessageReaction,
+    member: GuildMember,
+    message: GuildMessage,
+  ): Promise<void> {
+    const document = await ReactionRole.findOne({ messageId: message.id });
+    if (!document) {
+      this.context.client.reactionRolesIds = this.context.client.reactionRolesIds.filter(elt => elt !== message.id);
+      return;
     }
+
+    const { reaction: emoji, role: givenRoleId } = document.reactionRolePairs
+      .find(elt => elt.reaction === reaction.emoji.toString());
+    if (!emoji) {
+      reaction.remove().catch(noop);
+      return;
+    }
+
+    const givenRole = message.guild.roles.cache.get(givenRoleId);
+    if (!givenRole) {
+      this.context.logger.warn(`[Reaction Roles] The role with id ${givenRoleId} does not exists !`);
+      return;
+    }
+
+    if (member.roles.cache.get(givenRole.id))
+      member.roles.remove(givenRole).catch(noop);
+  }
+
+  private async _handleEclassRole(
+    _reaction: MessageReaction,
+    member: GuildMember,
+    message: GuildMessage,
+  ): Promise<void> {
+    const document = await Eclass.findOne({ announcementMessage: message.id });
+    if (!document) {
+      this.context.client.reactionRolesIds = this.context.client.reactionRolesIds.filter(elt => elt !== message.id);
+      return;
+    }
+
+    await EclassManager.unsubscribeMember(member, document);
   }
 }

--- a/src/events/ready.ts
+++ b/src/events/ready.ts
@@ -2,17 +2,18 @@ import { ApplyOptions } from '@sapphire/decorators';
 import type { EventOptions } from '@sapphire/framework';
 import { Event } from '@sapphire/framework';
 import type { TextChannel } from 'discord.js';
+import Eclass from '@/models/eclass';
 import FlaggedMessageDB from '@/models/flaggedMessage';
 import ReactionRole from '@/models/reactionRole';
 import FlaggedMessage from '@/structures/FlaggedMessage';
-import { ConfigEntries } from '../lib/types/database';
+import { ConfigEntries, EclassStatus } from '@/types/database';
 
 @ApplyOptions<EventOptions>({ once: true })
 export default class ReadyEvent extends Event {
   public async run(): Promise<void> {
     this.context.client.checkValidity();
 
-    this.context.logger.info('[Reaction Roles] Caching reactions roles...');
+    this.context.logger.info('[Reaction Roles] Caching reactions-roles menus...');
     const reactionRoles = await ReactionRole.find();
     for (const rr of reactionRoles) {
       const channel = this.context.client.channels.cache.get(rr.channelId);
@@ -23,6 +24,20 @@ export default class ReadyEvent extends Event {
           await ReactionRole.findByIdAndDelete(rr._id);
           this.context.client.reactionRolesIds = this.context.client.reactionRolesIds
             .filter(elt => elt !== rr.messageId);
+        });
+    }
+
+    this.context.logger.info('[Reaction Roles] Caching eclass annoucement...');
+    const eclasses = await Eclass.find({ status: EclassStatus.Planned });
+    for (const eclass of eclasses) {
+      const channel = await this.context.client.configManager.get(eclass.guild, eclass.announcementChannel);
+
+      channel.messages.fetch(eclass.announcementMessage)
+        .catch(async () => {
+          // If we failed to fetch the message, it is likely that it has been deleted, so we remove it too.
+          await ReactionRole.findByIdAndDelete(eclass._id);
+          this.context.client.reactionRolesIds = this.context.client.reactionRolesIds
+            .filter(elt => elt !== eclass.announcementMessage);
         });
     }
 

--- a/src/lib/models/eclass.ts
+++ b/src/lib/models/eclass.ts
@@ -1,0 +1,101 @@
+import dayjs from 'dayjs';
+import type { GuildMember } from 'discord.js';
+import { model, Schema } from 'mongoose';
+import slug from 'slug';
+import settings from '@/config/settings';
+import type { EclassDocument, EclassModel, PrettyEclass } from '@/types/database';
+import { ConfigEntries, EclassStatus } from '@/types/database';
+
+const EclassSchema = new Schema<EclassDocument, EclassModel>({
+  classId: {
+    type: String,
+    required: true,
+    index: true,
+  },
+  classChannel: {
+    type: String,
+    required: true,
+  },
+  guild: {
+    type: String,
+    required: true,
+  },
+  topic: {
+    type: String,
+    required: true,
+  },
+  subject: {
+    type: String,
+    required: true,
+  },
+  date: {
+    type: Number,
+    required: true,
+  },
+  duration: {
+    type: Number,
+    required: true,
+  },
+  end: {
+    type: Number,
+    default(this: EclassDocument): number { return this.date + this.duration; },
+  },
+  professor: {
+    type: String,
+    required: true,
+  },
+  classRole: {
+    type: String,
+    required: true,
+    index: true,
+  },
+  targetRole: {
+    type: String,
+    required: true,
+  },
+  announcementChannel: {
+    type: String,
+    required: true,
+    enum: ConfigEntries,
+  },
+  announcementMessage: {
+    type: String,
+    required: true,
+  },
+  status: {
+    type: Number,
+    default: EclassStatus.Planned,
+    enum: EclassStatus,
+  },
+  reminded: {
+    type: Boolean,
+    default: false,
+  },
+  subscribers: [String],
+}, { timestamps: true });
+
+const pad = (n: number): string => n.toString().padStart(2, '0');
+
+EclassSchema.statics.generateId = function (topic: string, professor: GuildMember, date: Date): string {
+  return slug([
+    slug(topic, ''),
+    slug(professor.displayName),
+    `${pad(date.getHours())}${pad(date.getMinutes())}`,
+    `${pad(date.getDate())}${pad(date.getMonth() + 1)}`,
+    date.getFullYear(),
+  ].join('_'), '_');
+};
+
+EclassSchema.methods.toData = function (): PrettyEclass {
+  // eslint-disable-next-line @typescript-eslint/naming-convention
+  const { _id, __v, ...doc } = this.toObject();
+
+  return {
+    ...doc,
+    date: dayjs(doc.date).format(settings.configuration.dateFormat),
+    end: dayjs(doc.end).format(settings.configuration.dateFormat),
+    duration: dayjs.duration(doc.duration).humanize(),
+  };
+};
+
+export default model<EclassDocument, EclassModel>('Eclass', EclassSchema);

--- a/src/lib/structures/ArgumentPrompter.ts
+++ b/src/lib/structures/ArgumentPrompter.ts
@@ -1,0 +1,185 @@
+import type { IMessagePrompterExplicitMessageReturn } from '@sapphire/discord.js-utilities';
+import { MessagePrompter, MessagePrompterStrategies } from '@sapphire/discord.js-utilities';
+import type { GuildMember, Role } from 'discord.js';
+import messages from '@/config/messages';
+import settings from '@/config/settings';
+import ArgumentResolver from '@/structures/ArgumentResolver';
+import type { GuildMessage, GuildTextBasedChannel, HourMinutes } from '@/types';
+
+// Overwrite 'appliedMessage' and 'response' in 'IMessagePrompterExplicitMessageReturn' for them
+// to be GuildMessages rather than Messages
+type PrompterMessageResult = Omit<IMessagePrompterExplicitMessageReturn, 'appliedMessage' | 'response'> & { response: GuildMessage; appliedMessage: GuildMessage };
+type PrompterText = Record<'base' | 'invalid', string>;
+
+export default class ArgumentPrompter {
+  constructor(
+    private readonly _message: GuildMessage,
+    private readonly _messageArray?: GuildMessage[],
+  ) {}
+
+  public async autoPromptTextChannel(prompts?: PrompterText): Promise<GuildTextBasedChannel> {
+    let response = await this.promptTextChannel(prompts);
+    while (!response)
+      response = await this.promptTextChannel(prompts, true);
+    return response;
+  }
+
+  public async autoPromptMessage(prompts?: PrompterText): Promise<GuildMessage> {
+    let response = await this.promptMessage(prompts);
+    while (!response)
+      response = await this.promptMessage(prompts, true);
+    return response;
+  }
+
+  public async autoPromptText(prompts?: PrompterText): Promise<string> {
+    let response = await this.promptText(prompts);
+    while (!response)
+      response = await this.promptText(prompts, true);
+    return response;
+  }
+
+  public async autoPromptDate(prompts?: PrompterText): Promise<Date> {
+    let response = await this.promptDate(prompts);
+    while (!response)
+      response = await this.promptDate(prompts, true);
+    return response;
+  }
+
+  public async autoPromptHour(prompts?: PrompterText): Promise<HourMinutes> {
+    let response = await this.promptHour(prompts);
+    while (!response)
+      response = await this.promptHour(prompts, true);
+    return response;
+  }
+
+  public async autoPromptDuration(prompts?: PrompterText): Promise<number> {
+    let response = await this.promptDuration(prompts);
+    while (!response)
+      response = await this.promptDuration(prompts, true);
+    return response;
+  }
+
+  public async autoPromptMember(prompts?: PrompterText): Promise<GuildMember> {
+    let response = await this.promptMember(prompts);
+    while (!response)
+      response = await this.promptMember(prompts, true);
+    return response;
+  }
+
+  public async autoPromptRole(prompts?: PrompterText): Promise<Role> {
+    let response = await this.promptRole(prompts);
+    while (!response)
+      response = await this.promptRole(prompts, true);
+    return response;
+  }
+
+  public async promptTextChannel(prompts?: PrompterText, previousIsFailure = false): Promise<GuildTextBasedChannel> {
+    const response = await this._prompt(
+      previousIsFailure
+        ? `${prompts.invalid || messages.prompts.channel.invalid} ${prompts.base || messages.prompts.channel.base}`
+        : prompts.base || messages.prompts.channel.base,
+    );
+
+    if (response.mentions.channels.size > 0 && response.mentions.channels.first().isText())
+      return response.mentions.channels.first();
+
+    const query = response.content.split(' ').join('-');
+    return ArgumentResolver.resolveChannelByID(query, response.guild)
+      ?? ArgumentResolver.resolveChannelByQuery(query, response.guild);
+  }
+
+  public async promptMessage(prompts?: PrompterText, previousIsFailure = false): Promise<GuildMessage> {
+    const response = await this._prompt(
+      previousIsFailure
+        ? `${prompts.invalid || messages.prompts.message.invalid} ${prompts.base || messages.prompts.message.base}`
+        : prompts.base || messages.prompts.message.base,
+    );
+
+    return await ArgumentResolver.resolveMessageByID(response.content, response.channel)
+      ?? await ArgumentResolver.resolveMessageByLink(response.content, response.guild, response.author);
+  }
+
+  public async promptText(prompts?: PrompterText, previousIsFailure = false): Promise<string> {
+    const response = await this._prompt(
+      previousIsFailure
+        ? `${prompts.invalid || messages.prompts.text.invalid} ${prompts.base || messages.prompts.text.base}`
+        : prompts.base || messages.prompts.text.base,
+    );
+
+    return response.content;
+  }
+
+  public async promptDate(prompts?: PrompterText, previousIsFailure = false): Promise<Date> {
+    const response = await this._prompt(
+      previousIsFailure
+        ? `${prompts.invalid || messages.prompts.date.invalid} ${prompts.base || messages.prompts.date.base}`
+        : prompts.base || messages.prompts.date.base,
+    );
+
+    return ArgumentResolver.resolveDate(response.content);
+  }
+
+  public async promptHour(prompts?: PrompterText, previousIsFailure = false): Promise<HourMinutes> {
+    const response = await this._prompt(
+      previousIsFailure
+        ? `${prompts.invalid || messages.prompts.hour.invalid} ${prompts.base || messages.prompts.hour.base}`
+        : prompts.base || messages.prompts.hour.base,
+    );
+
+    return ArgumentResolver.resolveHour(response.content);
+  }
+
+  public async promptDuration(prompts?: PrompterText, previousIsFailure = false): Promise<number> {
+    const response = await this._prompt(
+      previousIsFailure
+        ? `${prompts.invalid || messages.prompts.duration.invalid} ${prompts.base || messages.prompts.duration.base}`
+        : prompts.base || messages.prompts.duration.base,
+    );
+
+    return ArgumentResolver.resolveDuration(response.content);
+  }
+
+  public async promptMember(prompts?: PrompterText, previousIsFailure = false): Promise<GuildMember> {
+    const response = await this._prompt(
+      previousIsFailure
+        ? `${prompts.invalid || messages.prompts.member.invalid} ${prompts.base || messages.prompts.member.base}`
+        : prompts.base || messages.prompts.member.base,
+    );
+
+    if (response.mentions.members.size > 0)
+      return response.mentions.members.first();
+
+    return ArgumentResolver.resolveMemberByQuery(response.content, response.guild)
+      ?? await ArgumentResolver.resolveMemberByID(response.content, response.guild);
+  }
+
+  public async promptRole(prompts?: PrompterText, previousIsFailure = false): Promise<Role> {
+    const response = await this._prompt(
+      previousIsFailure
+        ? `${prompts.invalid || messages.prompts.role.invalid} ${prompts.base || messages.prompts.role.base}`
+        : prompts.base || messages.prompts.role.base,
+    );
+
+    if (response.mentions.roles.size > 0)
+      return response.mentions.roles.first();
+
+    return ArgumentResolver.resolveRoleByID(response.content, response.guild)
+      ?? ArgumentResolver.resolveRoleByQuery(response.content, response.guild);
+  }
+
+  private async _prompt(text: string): Promise<GuildMessage> {
+    const handler = new MessagePrompter(
+      text,
+      MessagePrompterStrategies.Message,
+      { timeout: 60 * 1000, explicitReturn: true },
+    );
+    const { response, appliedMessage } = await handler
+      .run(this._message.channel, this._message.author) as PrompterMessageResult;
+    if (this._messageArray)
+      this._messageArray.push(response, appliedMessage);
+
+    if (settings.configuration.stop.has(response.content))
+      throw new Error('STOP');
+    return response;
+  }
+}

--- a/src/lib/structures/ArgumentResolver.ts
+++ b/src/lib/structures/ArgumentResolver.ts
@@ -5,11 +5,19 @@ import {
   MessageLinkRegex,
   RoleMentionRegex,
   SnowflakeRegex,
+  UserOrMemberMentionRegex,
 } from '@sapphire/discord.js-utilities';
-import type { Guild, Role, User } from 'discord.js';
+import type {
+  Guild,
+  GuildMember,
+  Role,
+  User,
+ } from 'discord.js';
 import { Permissions } from 'discord.js';
-import type { GuildMessage, GuildTextBasedChannel } from '@/types';
-import { nullop } from '@/utils';
+import type { GuildMessage, GuildTextBasedChannel, HourMinutes } from '@/types';
+import { getDuration, nullop } from '@/utils';
+
+const DATE_REGEX = /^(?<day>\d{1,2})[/-](?<month>\d{1,2})$/imu;
 
 export default {
   resolveChannelByID(argument: string, guild: Guild): GuildTextBasedChannel {
@@ -37,6 +45,17 @@ export default {
     return guild.roles.cache.find(role => role.name.toLowerCase() === queryLower);
   },
 
+  async resolveMemberByID(argument: string, guild: Guild): Promise<GuildMember> {
+    const memberID = UserOrMemberMentionRegex.exec(argument) ?? SnowflakeRegex.exec(argument);
+    return guild.members.cache.get(memberID?.[1]) ?? await guild.members.fetch(memberID?.[1]).catch(nullop) ?? null;
+  },
+
+  resolveMemberByQuery(query: string, guild: Guild): GuildMember {
+    const queryLower = query.toLowerCase();
+    return guild.members.cache.find(member =>
+      member.user.username.toLowerCase() === queryLower || member.displayName.toLowerCase() === queryLower);
+  },
+
   async resolveMessageByID(argument: string, channel: GuildTextBasedChannel): Promise<GuildMessage> {
     const message = SnowflakeRegex.test(argument)
       ? await channel.messages.fetch(argument).catch(nullop) as GuildMessage
@@ -62,5 +81,45 @@ export default {
 
     const message = await channel.messages.fetch(messageID).catch(nullop) as GuildMessage;
     return message;
+  },
+
+  resolveDate(argument: string): Date {
+    if (!DATE_REGEX.test(argument))
+      return null;
+
+    const groups = DATE_REGEX.exec(argument)?.groups;
+    const date = new Date();
+    date.setMonth(Number.parseInt(groups?.month, 10) - 1);
+    date.setDate(Number.parseInt(groups?.day, 10));
+    date.setHours(0, 0, 0, 0);
+
+    const time = date.getTime();
+    if (Number.isNaN(time))
+      return null;
+
+    return date;
+  },
+
+  resolveHour(argument: string): HourMinutes {
+    const HOUR_REGEX = /^(?<hour>\d{1,2})[h:]?(?<minutes>\d{2})?$/imu;
+    const hour = Number.parseInt(HOUR_REGEX.exec(argument)?.groups?.hour, 10);
+    const minutes = Number.parseInt(HOUR_REGEX.exec(argument)?.groups?.minutes, 10) || 0;
+
+    if (!hour)
+      return null;
+
+    return {
+      hour,
+      minutes,
+      formatted: `${hour}h${minutes.toString().padStart(2, '0')}`,
+    };
+  },
+
+  resolveDuration(argument: string): number {
+    try {
+      return getDuration(argument.replace(' ', ''));
+    } catch {
+      return null;
+    }
   },
 };

--- a/src/lib/structures/ConfigurationManager.ts
+++ b/src/lib/structures/ConfigurationManager.ts
@@ -2,8 +2,7 @@ import { Collection } from 'discord.js';
 import Configuration from '@/models/configuration';
 import type MonkaClient from '@/structures/MonkaClient';
 import type { GuildTextBasedChannel } from '@/types';
-import { ConfigEntries } from '@/types/database';
-import type { ConfigurationDocument } from '@/types/database';
+import type { ConfigEntries, ConfigurationDocument } from '@/types/database';
 import { nullop } from '@/utils';
 
 export default class ConfigurationManager {
@@ -14,22 +13,22 @@ export default class ConfigurationManager {
 
   public async set(channel: ConfigEntries, value: GuildTextBasedChannel): Promise<void> {
     await Configuration.findOneAndUpdate(
-      { guild: value.guild.id, name: ConfigEntries.ModeratorFeedback },
+      { guild: value.guild.id, name: channel },
       { guild: value.guild.id, value: value.id },
       { upsert: true },
     );
-    this.channels.set(value.guild.id, { [channel]: value });
+    this.channels.set(value.guild.id, { [channel]: value } as Record<ConfigEntries, GuildTextBasedChannel>);
   }
 
   public async get(guildID: string, channel: ConfigEntries): Promise<GuildTextBasedChannel> {
     if (this.channels.get(guildID)?.[channel])
       return this.channels.get(guildID)[channel];
 
-    const result = await Configuration.findOne({ guild: guildID, name: ConfigEntries.ModeratorFeedback }).catch(nullop);
+    const result = await Configuration.findOne({ guild: guildID, name: channel }).catch(nullop);
     if (result?.value) {
       const resolvedChannel = this.client.channels.resolve(result.value);
       if (resolvedChannel.isText() && resolvedChannel.type !== 'dm') {
-        this.channels.set(guildID, { [channel]: resolvedChannel });
+        this.channels.set(guildID, { [channel]: resolvedChannel } as Record<ConfigEntries, GuildTextBasedChannel>);
         return resolvedChannel;
       }
     }
@@ -44,7 +43,9 @@ export default class ConfigurationManager {
     for (const channel of configuredChannels) {
       this.channels.set(
         channel.guild,
-        { [channel.name]: this.client.channels.resolve(channel.value) as GuildTextBasedChannel },
+        {
+          [channel.name]: this.client.channels.resolve(channel.value),
+        } as Record<ConfigEntries, GuildTextBasedChannel>,
       );
     }
   }

--- a/src/lib/structures/EclassManager.ts
+++ b/src/lib/structures/EclassManager.ts
@@ -1,0 +1,282 @@
+import { Store } from '@sapphire/pieces';
+import dayjs from 'dayjs';
+import type { GuildMember, Role } from 'discord.js';
+import { MessageEmbed } from 'discord.js';
+import pupa from 'pupa';
+import twemoji from 'twemoji';
+import { eclass as config } from '@/config/commands/professors';
+import settings from '@/config/settings';
+import Eclass from '@/models/eclass';
+import type { GuildMessage, GuildTextBasedChannel } from '@/types';
+import type { EclassDocument } from '@/types/database';
+import { ConfigEntries, EclassStatus } from '@/types/database';
+import { capitalize, massSend, noop } from '@/utils';
+
+const EMOJI_URL_REGEX = /src="(?<url>.*)"/;
+
+const classAnnoucement: Record<SchoolYear, ConfigEntries> = {
+  l1: ConfigEntries.ClassAnnoucementL1,
+  l2: ConfigEntries.ClassAnnoucementL2,
+  l3: ConfigEntries.ClassAnnoucementL3,
+  general: ConfigEntries.ClassAnnoucementGeneral,
+};
+
+type SchoolYear = 'general' | 'l1' | 'l2' | 'l3';
+interface EclassCreationOptions {
+  date: Date;
+  classChannel: GuildTextBasedChannel;
+  topic: string;
+  duration: number;
+  professor: GuildMember;
+  targetRole: Role;
+}
+
+interface EclassEmbedOptions {
+  subject: string;
+  topic: string;
+  formattedDate: string;
+  duration: number;
+  professor: GuildMember;
+  classChannel: GuildTextBasedChannel;
+  classId: string;
+}
+
+// eslint-disable-next-line @typescript-eslint/no-extraneous-class
+export default class EclassManager {
+  public static async createClass(
+    message: GuildMessage,
+    {
+      date, classChannel, topic, duration, professor, targetRole,
+    }: EclassCreationOptions,
+  ): Promise<void> {
+    // Prepare the date
+    const formattedDate = dayjs(date).format(settings.configuration.dateFormat);
+
+    // All channels start with an emote followed by the subject's name
+    const fullName = classChannel.name.split('-');
+    fullName.shift();
+    const subject = fullName.map(capitalize).join(' ');
+    const name = pupa(settings.configuration.eclassRoleFormat, { subject, topic, formattedDate });
+
+    if (message.guild.roles.cache.some(r => r.name === name)) {
+      await message.channel.send(config.messages.alreadyExists);
+      return;
+    }
+
+    // Extract the school year from the category channel (L1, L2, L3...)
+    const schoolYear = classChannel.parent.name.slice(-2).toLowerCase();
+    const target: SchoolYear = Object.keys(classAnnoucement).includes(schoolYear) ? schoolYear as SchoolYear : 'general';
+
+    // Get the corresponding annoucement channel
+    const channel = await Store.injectedContext.client.configManager.get(message.guild.id, classAnnoucement[target]);
+
+    if (!channel) {
+      Store.injectedContext.logger.warn(`[e-class] A new e-class was planned but no annoucement channel was found, unable to create. Setup an annoucement channel with "${settings.prefix}setup class"`);
+      await message.channel.send(config.messages.unconfiguredChannel);
+      return;
+    }
+
+    // Create & send the announcement embed
+    const embed = EclassManager.createAnnoucementEmbed({
+      subject,
+      topic,
+      formattedDate,
+      duration,
+      professor,
+      classChannel,
+      classId: '',
+    });
+    const announcementMessage = await channel.send({
+      content: pupa(config.messages.newClassNotification, { targetRole }),
+      embed,
+    });
+    // Add the reaction & cache the message
+    await announcementMessage.react(settings.emojis.yes);
+    Store.injectedContext.client.eclassRolesIds.push(announcementMessage.id);
+
+    // Create the role
+    const role = await message.guild.roles.create({ data: { name, color: settings.colors.white, mentionable: true } });
+
+    // Add the class to the database
+    const eclass = await Eclass.create({
+      classChannel: classChannel.id,
+      guild: classChannel.guild.id,
+      topic,
+      subject,
+      date: date.getTime(),
+      duration,
+      professor: professor.id,
+      classRole: role.id,
+      targetRole: targetRole.id,
+      announcementMessage: announcementMessage.id,
+      announcementChannel: classAnnoucement[target],
+      classId: Eclass.generateId(topic, professor, date),
+    });
+    // Use the newly created ID in the embed
+    await announcementMessage.edit({
+      content: announcementMessage.content,
+      embed: embed.setFooter(pupa(config.messages.newClassEmbed.footer, { eclass })),
+    });
+
+    // Send confirmation message
+    await message.channel.send(pupa(config.messages.successfullyCreated, { eclass }));
+  }
+
+  public static async startClass(eclass: EclassDocument): Promise<void> {
+    // Fetch the annoucement message
+    const announcementChannel = await Store.injectedContext.client.configManager
+      .get(eclass.guild, eclass.announcementChannel);
+    const announcementMessage = await announcementChannel.messages.fetch(eclass.announcementMessage);
+    // Update its embed
+    const announcementEmbed = announcementMessage.embeds[0];
+    announcementEmbed.setColor(settings.colors.orange);
+    announcementEmbed.fields.find(field => field.name === config.messages.newClassEmbed.date).value += ` ${config.messages.valueInProgress}`;
+    await announcementMessage.edit(announcementEmbed);
+
+    // Send an embed in the corresponding text channel
+    const classChannel = Store.injectedContext.client
+      .guilds.resolve(eclass.guild)
+      .channels.resolve(eclass.classChannel) as GuildTextBasedChannel;
+    const embed = new MessageEmbed()
+      .setColor(settings.colors.primary)
+      .setTitle(pupa(config.messages.startClassEmbed.title, { eclass }))
+      .setAuthor(config.messages.startClassEmbed.author, announcementChannel.guild.iconURL())
+      .setDescription(pupa(config.messages.startClassEmbed.description, { eclass }))
+      .setFooter(pupa(config.messages.startClassEmbed.footer, { eclass }));
+    await classChannel.send({
+      content: pupa(config.messages.startClassNotification, { classRole: eclass.classRole }),
+      embed,
+    });
+
+    // Mark the class as In Progress
+    await Eclass.findByIdAndUpdate(eclass._id, { status: EclassStatus.InProgress });
+  }
+
+  public static async finishClass(eclass: EclassDocument): Promise<void> {
+    // Fetch the annoucement message
+    const announcementChannel = await Store.injectedContext.client.configManager
+      .get(eclass.guild, eclass.announcementChannel);
+    const announcementMessage = await announcementChannel.messages.fetch(eclass.announcementMessage);
+    // Update its embed
+    const announcementEmbed = announcementMessage.embeds[0];
+    const statusField = announcementEmbed.fields.find(field => field.name === config.messages.newClassEmbed.date);
+    statusField.value = statusField.value.replace(config.messages.valueInProgress, config.messages.valueFinished);
+    await announcementMessage.edit(announcementEmbed);
+
+    // Remove the associated role
+    await Store.injectedContext.client
+      .guilds.cache.get(eclass.guild)
+      .roles.cache.get(eclass.classRole)
+      .delete('Class finished');
+
+    // Mark the class as finished
+    await Eclass.findByIdAndUpdate(eclass._id, { status: EclassStatus.Finished });
+  }
+
+  public static async cancelClass(eclass: EclassDocument): Promise<void> {
+    // Fetch the annoucement message
+    const announcementChannel = await Store.injectedContext.client.configManager
+      .get(eclass.guild, eclass.announcementChannel);
+    const announcementMessage = await announcementChannel.messages.fetch(eclass.announcementMessage);
+    // Update its embed
+    const announcementEmbed = announcementMessage.embeds[0];
+    announcementEmbed.setColor(settings.colors.red);
+    announcementEmbed.setDescription(config.messages.valueCanceled);
+    announcementEmbed.spliceFields(0, 25);
+    await announcementMessage.edit(announcementEmbed);
+    await announcementMessage.reactions.removeAll();
+    // Remove from cache
+    Store.injectedContext.client.eclassRolesIds = Store.injectedContext.client.eclassRolesIds
+      .filter(elt => elt !== announcementMessage.id);
+
+    // Remove the associated role
+    await Store.injectedContext.client
+      .guilds.cache.get(eclass.guild)
+      .roles.cache.get(eclass.classRole)
+      .delete('Class canceled');
+
+    // Mark the class as finished
+    await Eclass.findByIdAndUpdate(eclass._id, { status: EclassStatus.Canceled });
+  }
+
+  public static async remindClass(eclass: EclassDocument): Promise<void> {
+    // Resolve the associated channel
+    const guild = Store.injectedContext.client.guilds.resolve(eclass.guild);
+    const classChannel = guild.channels.resolve(eclass.classChannel) as GuildTextBasedChannel;
+    // Send the notification
+    await classChannel.send(
+      pupa(config.messages.remindClassNotification, {
+        classRole: eclass.classRole,
+        duration: dayjs.duration(settings.configuration.eclassReminderTime).humanize(),
+      }),
+    );
+    // Send the private message
+    await massSend(guild, eclass.subscribers, pupa(config.messages.remindClassPrivateNotification, { eclass }));
+
+    // Mark the reminder as sent
+    await Eclass.findByIdAndUpdate(eclass._id, { reminded: true });
+  }
+
+  public static createAnnoucementEmbed({
+    subject,
+    topic,
+    formattedDate,
+    duration,
+    professor,
+    classChannel,
+    classId,
+  }: EclassEmbedOptions): MessageEmbed {
+    const fullName = classChannel.name.split('-');
+    const baseEmoji = fullName.shift();
+    const image = EMOJI_URL_REGEX.exec(twemoji.parse(baseEmoji))?.groups?.url;
+
+    const texts = config.messages.newClassEmbed;
+    return new MessageEmbed()
+      .setColor(settings.colors.green)
+      .setTitle(pupa(texts.title, { subject, topic }))
+      .setDescription(pupa(texts.description, { subject, classChannel }))
+      .setThumbnail(image)
+      .setAuthor(texts.author, classChannel.guild.iconURL())
+      .addField(texts.date, formattedDate, true)
+      .addField(texts.duration, dayjs.duration(duration).humanize(), true)
+      .addField(texts.professor, professor, true)
+      .setFooter(pupa(texts.footer, { classId }));
+  }
+
+  public static async subscribeMember(member: GuildMember, eclass: EclassDocument): Promise<void> {
+    const givenRole = member.guild.roles.cache.get(eclass.classRole);
+    if (!givenRole) {
+      Store.injectedContext.logger.warn(`[e-class] The role with id ${eclass.classRole} does not exists !`);
+      return;
+    }
+
+    await Eclass.findByIdAndUpdate(eclass._id, { $push: { subscribers: member.id } });
+    if (!member.roles.cache.get(givenRole.id))
+      await member.roles.add(givenRole);
+
+    member.send(pupa(config.messages.subscribed, { subject: eclass.subject, topic: eclass.topic })).catch(noop);
+  }
+
+  public static async unsubscribeMember(member: GuildMember, eclass: EclassDocument): Promise<void> {
+    const givenRole = member.guild.roles.cache.get(eclass.classRole);
+    if (!givenRole) {
+      Store.injectedContext.logger.warn(`[Reaction Roles] The role with id ${eclass.classRole} does not exists !`);
+      return;
+    }
+
+    await Eclass.findByIdAndUpdate(eclass._id, { $pull: { subscribers: member.id } });
+    if (member.roles.cache.get(givenRole.id))
+      await member.roles.remove(givenRole);
+
+    member.send(pupa(config.messages.unsubscribed, { subject: eclass.subject, topic: eclass.topic })).catch(noop);
+  }
+
+  public static toStatus(eclass: EclassDocument): string {
+    switch (eclass.status) {
+      case EclassStatus.Planned: return config.messages.statuses.planned;
+      case EclassStatus.InProgress: return config.messages.statuses.inProgress;
+      case EclassStatus.Finished: return config.messages.statuses.finished;
+      case EclassStatus.Canceled: return config.messages.statuses.canceled;
+    }
+  }
+}

--- a/src/lib/structures/FlaggedMessage.ts
+++ b/src/lib/structures/FlaggedMessage.ts
@@ -163,7 +163,7 @@ export default class FlaggedMessage {
     if (this.logChannel) {
       const payload = { message: this.message, swear: this.swear };
       this.alertMessage = await this.logChannel.send(pupa(messages.antiSwear.swearModAlert, payload)) as GuildMessage;
-      await this.alertMessage.react('✅');
+      await this.alertMessage.react(settings.emojis.yes);
     } else {
       this.context.logger.warn(`[Anti Swear] A swear was detected but no log channel was found, unable to report. Setup a log channel with "${settings.prefix}setup mod"`);
     }

--- a/src/lib/structures/FlaggedMessage.ts
+++ b/src/lib/structures/FlaggedMessage.ts
@@ -7,7 +7,7 @@ import FlaggedMessageDB from '@/models/flaggedMessage';
 import type { GuildMessage, GuildTextBasedChannel } from '@/types';
 import type { FlaggedMessageDocument } from '@/types/database';
 import { ConfigEntries } from '@/types/database';
-import { nullop } from '../utils';
+import { nullop } from '@/utils';
 
 type FlaggedMessageData =
   | { manualModerator: GuildMember } & { swear?: never }

--- a/src/lib/types/augments.d.ts
+++ b/src/lib/types/augments.d.ts
@@ -2,7 +2,7 @@ import type ConfigurationManager from '@/structures/ConfigurationManager';
 import type FlaggedMessage from '@/structures/FlaggedMessage';
 import type MonkaCommand from '@/structures/MonkaCommand';
 import type TaskStore from '@/structures/TaskStore';
-import type { CodeLanguageResult, GuildTextBasedChannel } from '@/types';
+import type { CodeLanguageResult, GuildTextBasedChannel, HourMinutes } from '@/types';
 
 
 declare module 'discord.js' {
@@ -24,6 +24,7 @@ declare module '@sapphire/framework' {
     configManager: ConfigurationManager;
     remainingCompilerApiCredits: number;
     reactionRolesIds: string[];
+    eclassRolesIds: string[];
     waitingFlaggedMessages: FlaggedMessage[];
     intersectionRoles: string[];
   }
@@ -32,6 +33,9 @@ declare module '@sapphire/framework' {
     code: string;
     codeLanguage: CodeLanguageResult;
     command: MonkaCommand;
+    day: Date;
+    duration: number;
     guildTextBasedChannel: GuildTextBasedChannel;
+    hour: HourMinutes;
   }
 }

--- a/src/lib/types/database.ts
+++ b/src/lib/types/database.ts
@@ -1,12 +1,18 @@
+import type { GuildMember } from 'discord.js';
 import type { Document, Model } from 'mongoose';
 
 /* ****************************** */
 /*  Configuration Database Types  */
 /* ****************************** */
 
+// #region Configuration Database Types
 /** Enum for the "Configuration"'s mongoose schema */
 export enum ConfigEntries {
   ModeratorFeedback = 'moderator-feedback-channel',
+  ClassAnnoucementL1 = 'class-announcement-l1',
+  ClassAnnoucementL2 = 'class-announcement-l2',
+  ClassAnnoucementL3 = 'class-announcement-l3',
+  ClassAnnoucementGeneral = 'class-announcement-general',
 }
 
 /** Interface for the "Configuration"'s mongoose schema */
@@ -21,11 +27,59 @@ export interface ConfigurationDocument extends ConfigurationBase, Document {}
 
 /** Interface for the "Configuration"'s mongoose model */
 export type ConfigurationModel = Model<ConfigurationDocument>;
+// #endregion
+
+/* ****************************** */
+/*  Eclass Database Types  */
+/* ****************************** */
+
+// #region Eclass Database Types
+/** Enum for the "Eclass"'s mongoose schema */
+export enum EclassStatus {
+  Planned,
+  InProgress,
+  Finished,
+  Canceled,
+}
+
+/** Interface for the "Eclass"'s mongoose schema */
+export interface EclassBase {
+  classChannel: string;
+  guild: string;
+  topic: string;
+  subject: string;
+  date: number;
+  duration: number;
+  end: number;
+  professor: string;
+  classRole: string;
+  targetRole: string;
+  announcementMessage: string;
+  announcementChannel: ConfigEntries;
+  status: EclassStatus;
+  reminded: boolean;
+  classId: string;
+  subscribers: string[];
+}
+
+export type PrettyEclass = Omit<EclassBase, 'date' | 'duration' | 'end'> & { date: string; duration: string; end: string };
+
+/** Interface for the "Eclass"'s mongoose document */
+export interface EclassDocument extends EclassBase, Document {
+  toData(): PrettyEclass;
+}
+
+/** Interface for the "Eclass"'s mongoose model */
+export interface EclassModel extends Model<EclassDocument> {
+  generateId(topic: string, professor: GuildMember, date: Date): string;
+}
+// #endregion
 
 /* ***************************** */
 /*  ReactionRole Database Types  */
 /* ***************************** */
 
+// #region ReactionRole Database Types
 /** Interface for the "ReactionRole"'s mongoose schema */
 export interface ReactionRoleBase {
   messageId: string;
@@ -39,11 +93,13 @@ export interface ReactionRoleDocument extends ReactionRoleBase, Document {}
 
 /** Interface for the "ReactionRole"'s mongoose model */
 export type ReactionRoleModel = Model<ReactionRoleDocument>;
+// #endregion
 
 /* ********************************* */
 /*  RoleIntersection Database Types  */
 /* ********************************* */
 
+// #region RoleIntersection Database Types
 /** Interface for the "RoleIntersection"'s mongoose schema */
 export interface RoleIntersectionBase {
   roleId: string;
@@ -56,12 +112,14 @@ export interface RoleIntersectionDocument extends RoleIntersectionBase, Document
 
 /** Interface for the "RoleIntersection"'s mongoose model */
 export type RoleIntersectionModel = Model<RoleIntersectionDocument>;
+// #endregion
 
 /* ********************************* */
 /*  FlaggedMessage Database Types  */
 /* ********************************* */
 
-/** Interface for the "RoleIntersection"'s mongoose schema */
+// #region FlaggedMessage Database Types
+/** Interface for the "FlaggedMessage"'s mongoose schema */
 export interface FlaggedMessageBase {
   guildId: string;
   channelId: string;
@@ -75,8 +133,9 @@ export interface FlaggedMessageBase {
   approvedDate: number;
 }
 
-/** Interface for the "RoleIntersection"'s mongoose document */
+/** Interface for the "FlaggedMessage"'s mongoose document */
 export interface FlaggedMessageDocument extends FlaggedMessageBase, Document {}
 
-/** Interface for the "RoleIntersection"'s mongoose model */
+/** Interface for the "FlaggedMessage"'s mongoose model */
 export type FlaggedMessageModel = Model<FlaggedMessageDocument>;
+// #endregion

--- a/src/lib/types/index.ts
+++ b/src/lib/types/index.ts
@@ -7,7 +7,7 @@ import type {
  Role,
  TextChannel,
 } from 'discord.js';
-import type MonkaClient from '../structures/MonkaClient';
+import type MonkaClient from '@/structures/MonkaClient';
 
 /* ************ */
 /*  Util types  */
@@ -61,6 +61,16 @@ export interface ReactionRolePair {
   role: Role;
 }
 
+export interface HourMinutes {
+  hour: number;
+  minutes: number;
+  formatted: string;
+}
+
+export interface DurationPart {
+  number: string;
+  unit: string;
+}
 
 export interface ReactionRoleReturnPayload {
   isError: boolean;

--- a/src/lib/types/index.ts
+++ b/src/lib/types/index.ts
@@ -60,3 +60,13 @@ export interface ReactionRolePair {
   reaction: string;
   role: Role;
 }
+
+
+export interface ReactionRoleReturnPayload {
+  isError: boolean;
+  errorPayload?: {
+    reactions?: string[];
+    roles?: string[];
+  };
+  reactionRoles: ReactionRolePair[];
+}

--- a/src/lib/utils/capitalize.ts
+++ b/src/lib/utils/capitalize.ts
@@ -1,0 +1,3 @@
+export default function capitalize(string: string): string {
+  return string[0].toUpperCase() + string.slice(1);
+}

--- a/src/lib/utils/getDuration.ts
+++ b/src/lib/utils/getDuration.ts
@@ -1,0 +1,133 @@
+import type { DurationPart } from '@/types';
+
+const REGEX = /^(?<number>\d+) ?(?<unit>\w+)$/i;
+
+enum Durations {
+  /* eslint-disable no-multi-spaces, @typescript-eslint/prefer-literal-enum-member */
+  Second = 1,
+  Minute = 1 * 60,
+  Hour   = 1 * 60 * 60,
+  Day    = 1 * 60 * 60 * 24,
+  Week   = 1 * 60 * 60 * 24 * 7,
+  Month  = 1 * 60 * 60 * 24 * 30,
+  Year   = 1 * 60 * 60 * 24 * 365,
+}
+
+function tokenize(str: string): string[] {
+  const units: string[] = [];
+  let buf = '';
+  let letter = false;
+
+  for (const char of str) {
+    if (['.', ','].includes(char)) {
+      buf += char;
+    } else if (Number.isNaN(Number.parseInt(char, 10))) {
+      buf += char;
+      letter = true;
+    } else {
+      if (letter) {
+        units.push(buf.trim());
+        buf = '';
+      }
+      letter = false;
+      buf += char;
+    }
+  }
+
+  if (buf.length > 0)
+    units.push(buf.trim());
+  return units;
+}
+
+// eslint-disable-next-line complexity
+function convert(num: number, type: string): number {
+  switch (type) {
+    case 'years':
+    case 'year':
+    case 'y':
+    case 'annees':
+    case 'années':
+    case 'annee':
+    case 'année':
+    case 'ans':
+    case 'an':
+    case 'a':
+      return num * Durations.Year;
+    case 'months':
+    case 'month':
+    case 'mois':
+    case 'mo':
+      return num * Durations.Month;
+    case 'weeks':
+    case 'week':
+    case 'w':
+    case 'semaines':
+    case 'semaine':
+    case 'sem':
+      return num * Durations.Week;
+    case 'days':
+    case 'day':
+    case 'd':
+    case 'jours':
+    case 'jour':
+    case 'j':
+      return num * Durations.Day;
+    case 'hours':
+    case 'hour':
+    case 'heures':
+    case 'heure':
+    case 'hrs':
+    case 'hr':
+    case 'h':
+      return num * Durations.Hour;
+    case 'minutes':
+    case 'minute':
+    case 'mins':
+    case 'min':
+    case 'm':
+      return num * Durations.Minute;
+    case 'seconds':
+    case 'second':
+    case 'secondes':
+    case 'seconde':
+    case 'secs':
+    case 'sec':
+    case 's':
+      return num * Durations.Second;
+    default:
+      throw new TypeError(`Invalid duration unit: ${type}`);
+  }
+}
+
+/**
+ * Parses a human duration to a timestamp in seconds.
+ * @param {string} val - The value to parse as a duration.
+ * @returns number
+ * @throws {TypeError} - If the given duration is invalid, it will throw a TypeError
+ */
+function getDuration(val: string): number {
+  let abs: number;
+  let total = 0;
+  if (val.length > 0 && val.length < 101) {
+    const parts: DurationPart[] = tokenize(val.toLowerCase())
+      .map((part: string): DurationPart => {
+        const groups = REGEX.exec(part)?.groups;
+        if (!groups || !groups.number || !groups.unit)
+          throw new TypeError(`Value is an invalid duration (${JSON.stringify(val)})`);
+
+        return { number: groups.number, unit: groups.unit };
+      });
+    if (parts.length > 0) {
+      for (const { number, unit } of parts) {
+        if (number && unit) {
+          abs = Number.parseInt(number, 10);
+          total += convert(abs, unit);
+        }
+      }
+    }
+    return total;
+  }
+  throw new TypeError(`Value is an empty string, an invalid number, or too long (>100). Value=${JSON.stringify(val)}`);
+}
+
+export default getDuration;

--- a/src/lib/utils/index.ts
+++ b/src/lib/utils/index.ts
@@ -1,6 +1,10 @@
+export { default as capitalize } from './capitalize';
 export { default as commaListAnd } from './commaListAnd';
 export { default as convertSize } from './convertSize';
 export { default as firstAndRest } from './firstAndRest';
 export { default as generateSubcommands } from './generateSubcommands';
+export { default as getDuration } from './getDuration';
 export { default as getGitRev } from './getGitRev';
+export { default as massSend } from './massSend';
 export { noop, nullop } from './noop';
+export { default as sleep } from './sleep';

--- a/src/lib/utils/massSend.ts
+++ b/src/lib/utils/massSend.ts
@@ -1,0 +1,17 @@
+import type { Guild } from 'discord.js';
+import { noop, nullop } from './noop';
+import sleep from './sleep';
+
+export default async function massSend(guild: Guild, memberIds: string[], text: string): Promise<void> {
+  const shouldThrottle = memberIds.length > 30;
+
+  for (const [i, memberId] of memberIds.entries()) {
+    if (shouldThrottle && i % 10 === 0 && i !== 0)
+      await sleep(2000);
+
+    const member = guild.members.resolve(memberId)
+      ?? await guild.members.fetch({ user: memberId, cache: false }).catch(nullop);
+    if (member)
+      await member.send(text).catch(noop);
+  }
+}

--- a/src/lib/utils/sleep.ts
+++ b/src/lib/utils/sleep.ts
@@ -1,0 +1,5 @@
+export default async function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => {
+    setTimeout(resolve, ms);
+  });
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -8,6 +8,7 @@ import 'source-map-support/register';
 
 import dayjs from 'dayjs';
 import duration from 'dayjs/plugin/duration';
+import isBetween from 'dayjs/plugin/isBetween';
 import relativeTime from 'dayjs/plugin/relativeTime';
 import mongoose from 'mongoose';
 import MonkaClient from '@/structures/MonkaClient';
@@ -17,6 +18,7 @@ console.log('Starting MonkaBot...');
 dayjs.locale('fr');
 dayjs.extend(duration);
 dayjs.extend(relativeTime);
+dayjs.extend(isBetween);
 
 const main = async (): Promise<void> => {
   await mongoose.connect(process.env.MONGO_URI, {

--- a/src/tasks/manageEclass.ts
+++ b/src/tasks/manageEclass.ts
@@ -1,0 +1,42 @@
+import { ApplyOptions } from '@sapphire/decorators';
+import settings from '@/config/settings';
+import Eclass from '@/models/eclass';
+import EclassManager from '@/structures/EclassManager';
+import Task from '@/structures/Task';
+import type { TaskOptions } from '@/structures/Task';
+import { EclassStatus } from '@/types/database';
+
+@ApplyOptions<TaskOptions>({ delay: 2 * 60 * 1000 /* Every 2 minutes */ })
+export default class ManageEclassTask extends Task {
+  public async run(): Promise<void> {
+    const eclasses = await Eclass.find({
+      // This queries find classes that:
+      // - are planned and we reached the beggining (to start it)
+      // - are planned and we are 15 minutes before (to send a reminder)
+      // - are in progress and we reach the end (to finish it)
+      $or: [{
+        status: EclassStatus.Planned,
+        date: { $lte: Date.now() },
+        reminded: true,
+      }, {
+        status: EclassStatus.Planned,
+        date: { $lte: Date.now() + settings.configuration.eclassReminderTime },
+        reminded: false,
+      }, {
+        status: EclassStatus.InProgress,
+        end: { $lte: Date.now() },
+      }],
+    });
+    if (eclasses.length === 0)
+      return;
+
+    for (const eclass of eclasses) {
+      if (eclass.status === EclassStatus.Planned && eclass.reminded)
+        await EclassManager.startClass(eclass);
+      if (eclass.status === EclassStatus.Planned && !eclass.reminded)
+        await EclassManager.remindClass(eclass);
+      else if (eclass.status === EclassStatus.InProgress)
+        await EclassManager.finishClass(eclass);
+    }
+  }
+}


### PR DESCRIPTION
Ajoute la possibilité de gérer les e-cours via des commandes avec le bot.
Roadmap :
- [x] Création
- [x] Abonnement (réagir avec :white_check_mark:)
- [x] Lancer manuellement (`!cours start`)
- [x] Lancer automatiquement (à l'heure convenue)
- [x] Arrêter manuellement (`!cours finish`)
- [x] Arrêter automatiquement (au bout de la durée)
- [x] Annuler un cours (= supprimer définitivement ?)
- [x] Modification d'une classe (modif date, heure, prof, matière, sujet, channel associé, targetRole, durée) + ping (optionnel)
- [x] Rappels (15min avant / au moment)
- [x] Mieux gérer les dates (ne pas choisir la même année si mois prévu < mois actuel, et se projeter max 2 mois en avance)
- [ ] Gestion des messages de calendrier (résumé des cours de la semaine + archive)
- [x] Utiliser des IDs plutôt que le rôle créé ? (pour le start/finish/edit par exemple)
- [ ] Bug hunting/fixing

Non prioritaire :
- [x] Rappel en DM aux membres
- [ ] Pouvoir ne plus recevoir d'alertes en DM
- [ ] Interdire de créer une classe moins de 15min avant son commencement
- [ ] Envoyer un DM au prof avec des infos sur la procédure, etc
- [ ] Prévenir si un cours est déjà prévu pour la promo vers les mêmes horaires
- [ ] Ajouter une confirmation de création de cours (embed) avant de le créer
- [ ] Ajouter le channel vocal correspondant au cours dans les messages d'annonce
- [ ] Quand on est un prof avec un cours _**en cours**_, et qu'on fait `!class finish` ou `!class cancel` sans ID, ca sélectionne automatiquement notre cours.

Autre :
- [x] Rebase sur master
- [x] Rebase pour les commits